### PR TITLE
Add sentinel peer and last bundle height to status

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -81,6 +81,8 @@ func (emptySidecar) EnableTxsAvailable()           {}
 func (emptySidecar) Size() int       { return 0 }
 func (emptySidecar) TxsBytes() int64 { return 0 }
 
+func (emptySidecar) GetLastBundleHeight() int64 { return 0 }
+
 //-----------------------------------------------------------------------------
 // mockProxyApp uses ABCIResponses to give the right results.
 //

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -147,6 +147,9 @@ type PriorityTxSidecar interface {
 
 	// TxsBytes returns the total size of all txs in the mempool.
 	TxsBytes() int64
+
+	// Gets the height of the last received bundle tx. For status rpc purposes.
+	GetLastBundleHeight() int64
 }
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects

--- a/mempool/v0/clist_sidecar.go
+++ b/mempool/v0/clist_sidecar.go
@@ -22,6 +22,7 @@ type CListPriorityTxSidecar struct {
 	height                 int64 // the last block Update()'d to
 	heightForFiringAuction int64 // the height of the block to fire the auction for
 	txsBytes               int64 // total size of sidecar, in bytes
+	lastBundleHeight       int64 // height of last accepted bundle tx, for status rpc purposes
 
 	// notify listeners (ie. consensus) when txs are available
 	notifiedTxsAvailable bool
@@ -245,6 +246,8 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 	atomic.AddInt64(&sc.txsBytes, int64(len(scTx.Tx)))
 	fmt.Println("[mev-tendermint]: AddTx(): actually added the tx to the sc.txs CList, sidecar size is now", sc.Size())
 
+	sc.lastBundleHeight = scTx.DesiredHeight
+
 	// TODO: in the future, refactor to only notifyTxsAvailable when we have at least one full bundle
 	if sc.Size() > 0 {
 		sc.notifyTxsAvailable()
@@ -253,6 +256,11 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 	fmt.Println("[mev-tendermint]: ADDING SIDECAR TX FUNCTION COMPLETION")
 
 	return nil
+}
+
+// Gets the height of the last received bundle tx. For status rpc purposes.
+func (sc *CListPriorityTxSidecar) GetLastBundleHeight() int64 {
+	return sc.lastBundleHeight
 }
 
 // TxsWaitChan returns a channel to wait on transactions. It will be closed

--- a/node/node.go
+++ b/node/node.go
@@ -230,6 +230,8 @@ type Node struct {
 	blockIndexer      indexer.BlockIndexer
 	indexerService    *txindex.IndexerService
 	prometheusSrv     *http.Server
+
+	sidecar           *mempoolv0.CListPriorityTxSidecar
 }
 
 func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
@@ -953,6 +955,7 @@ func NewNode(config *cfg.Config,
 		indexerService:   indexerService,
 		blockIndexer:     blockIndexer,
 		eventBus:         eventBus,
+		sidecar:          sidecar.(*mempoolv0.CListPriorityTxSidecar),
 	}
 	node.BaseService = *service.NewBaseService(logger, "Node", node)
 
@@ -1136,10 +1139,12 @@ func (n *Node) ConfigureRPC() error {
 		ConsensusReactor: n.consensusReactor,
 		EventBus:         n.eventBus,
 		Mempool:          n.mempool,
+		Sidecar:          n.sidecar,
 
 		Logger: n.Logger.With("module", "rpc"),
 
 		Config: *n.config.RPC,
+		SidecarConfig: *n.config.Sidecar,
 	})
 	if err := rpccore.InitGenesisChunks(); err != nil {
 		return err

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -93,10 +93,12 @@ type Environment struct {
 	ConsensusReactor *consensus.Reactor
 	EventBus         *types.EventBus // thread safe
 	Mempool          mempl.Mempool
+	Sidecar          mempl.PriorityTxSidecar
 
 	Logger log.Logger
 
-	Config cfg.RPCConfig
+	Config        cfg.RPCConfig
+	SidecarConfig cfg.SidecarConfig
 
 	// cache of chunked genesis data.
 	genChunks []string

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"time"
+	"strings"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/p2p"
@@ -51,6 +52,17 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 		votingPower = val.VotingPower
 	}
 
+	var (
+		isPeeredWithRelayer      bool
+		lastReceivedBundleHeight int64
+	)
+
+	if relayer := env.SidecarConfig.Relayer; relayer != "" {
+		isPeeredWithRelayer = env.P2PPeers.Peers().Has(p2p.ID(strings.Split(relayer, "@")[0]))
+	}
+
+	lastReceivedBundleHeight = env.Sidecar.GetLastBundleHeight()
+
 	result := &ctypes.ResultStatus{
 		NodeInfo: env.P2PTransport.NodeInfo().(p2p.DefaultNodeInfo),
 		SyncInfo: ctypes.SyncInfo{
@@ -68,6 +80,10 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			Address:     env.PubKey.Address(),
 			PubKey:      env.PubKey,
 			VotingPower: votingPower,
+		},
+		MevInfo: ctypes.MevInfo{
+			IsPeeredWithRelayer:       isPeeredWithRelayer,
+			LastReceivedBundleHeight:  lastReceivedBundleHeight,
 		},
 	}
 

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -91,11 +91,17 @@ type ValidatorInfo struct {
 	VotingPower int64          `json:"voting_power"`
 }
 
+type MevInfo struct {
+	IsPeeredWithRelayer         bool   `json:"is_peered_with_relayer"`
+	LastReceivedBundleHeight    int64  `json:"last_received_bundle_height"`
+}
+
 // Node Status
 type ResultStatus struct {
 	NodeInfo      p2p.DefaultNodeInfo `json:"node_info"`
 	SyncInfo      SyncInfo            `json:"sync_info"`
 	ValidatorInfo ValidatorInfo       `json:"validator_info"`
+	MevInfo       MevInfo             `json:"mev_info"`
 }
 
 // Is TxIndexing enabled


### PR DESCRIPTION
new `mev_info` field in status rpc response, contains whether the node is peered with the sentinel, and the height of the last received bundle tx.
```
{
  "jsonrpc": "2.0",
  "id": -1,
  "result": {
    "node_info": {
      "protocol_version": {
        "p2p": "8",
        "block": "11",
        "app": "0"
      },
      "id": "5740acbf39a9ae59953801fe4997421b6736e091",
      "listen_addr": "tcp://0.0.0.0:26656",
      "network": "juno-skip-1",
      "version": "../mev-tendermint",
      "channels": "4020212223308038606100",
      "moniker": "sentry-3",
      "other": {
        "tx_index": "on",
        "rpc_address": "tcp://0.0.0.0:26657"
      }
    },
    "sync_info": {
      "latest_block_hash": "89840A8409A636D2ACBC55A7AC68EFE08170B0B4ACBD9D5766718B3F5318ACEB",
      "latest_app_hash": "CA145CE5D7ABD43D98300BC0F92163C1D8C6BF0B9ED3FCB25209CA250316623C",
      "latest_block_height": "23607",
      "latest_block_time": "2022-10-12T20:23:13.28793861Z",
      "earliest_block_hash": "E2AD105A2E9FB2170AB3F978E3264C522E64FB788A2CF971F638ACD9DACB39F3",
      "earliest_app_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
      "earliest_block_height": "1",
      "earliest_block_time": "2022-10-03T23:40:24.676981Z",
      "catching_up": false
    },
    "validator_info": {
      "address": "8DA73D80F214AD9C8A5F93B8898D2717584D2BEF",
      "pub_key": {
        "type": "tendermint/PubKeyEd25519",
        "value": "4WD6fcIpJD1dng06KgL5rFp7CB9SwrVeCLWbqMQwiO4="
      },
      "voting_power": "0"
    },
    "mev_info": {
      "is_peered_with_relayer": true,
      "last_received_bundle_height": "0"
    }
  }
}
```