### PR TITLE
Logging registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,122 @@
 
 ---
 
-### Design Goals
+# 👨‍💻 How to Integrate [~10min]
+
+**NOTE: if you have any questions/issues with integration, please ask us on our discord:  [https://discord.gg/amAgf9Z39w](https://discord.gg/amAgf9Z39w)**
+
+## 1. Information Skip Requires from you first  ℹ️
+
+In order to participate in the network, you must share with Skip (feel free to contact us at on our **[website](https://skip.money/)** or discord): 
+
+1. Your public **validator address hex** (see below for how to find)
+2. After you share this, we will give you an **API Key** (for now, please contact us on our [**discord](https://discord.gg/amAgf9Z39w)** to request)
+
+***How to find your validator address hex (run on your validator node)…***
+
+Via command line:
+
+```bash
+# run this command in terminal, substituting your HOME_DIR
+junod debug pubkey --home <HOME_DIR> $(junod tendermint show-validator --home <HOME_DIR>) |grep Address
+```
+
+From the `priv_validator_key.json`:
+
+```bash
+# run this command in terminal, substituting your HOME_DIR
+jq -r .address < <HOME_DIR>/config/priv_validator_key.json
+```
+
+Using Horcrux
+
+```bash
+# run this command in terminal
+horcrux cosigner address juno |jq -r .HexAddress
+```
+
+Via RPC to the validator node:
+
+```bash
+#run this command in terminal
+curl -s localhost:26657/status |jq -r .result.validator_info.address
+```
+
+***What is `<HOME_DIR>`?*** 
+
+- `*HOME_DIR` referenced above is the directory that stores your node config and data in subdirectories called `config` and `data`.*
+- *It defaults to `.<NETWORK_NAME>` if you don’t provide it (e.g. `.juno` or `.osmosis`). It is the same value you pass to the `--home` flag when starting your node.*
+
+## 2. Tendermint replacement ♻️
+
+In the `go.mod` file of the directory you use to compile your chain binary, you need to add a line to your `replace` to import the correct `mev-tendermint` version.
+
+**You can find the correct version of the replace you should use here:** [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c) 
+
+```tsx
+// ---------------------------------
+replace (
+	// Other stuff...
+	****github.com/tendermint/tendermint => github.com/skip-mev/mev-tendermint <USE CORRECT TAG FOR YOUR CHAIN>
+)
+```
+
+🚨 **After modifying the `replace` statement, run `go mod tidy` in your base directory**
+
+## 3. Peering Setup 🤝
+
+mev-tendermint introduces a new section of config in `config.toml` called `[sidecar].`
+
+…by the end, the end of your `config.toml` will look something like this (with different string values)
+
+```bash
+# OTHER CONFIG...
+
+[sidecar]
+relayer_conn_string = "d1463b730c6e0dcea59db726836aeaff13a8119f@<CORRECT IP>:<CORRECT PORT>"
+api_key = "2314ajinashg2389jfjap"
+validator_addr_hex = "B31A3C8EF75EDE09B6A3EC995EBB9E080B002DAE"
+personal_peer_ids = "557611c7a7307ce023a7d13486b570282521296d,5740acbf39a9ae59953801fe4997421b6736e091"
+```
+
+Here’s how to get these values…
+
+### `relayer_conn_string`
+
+- The `p2p@ip:port` for the Skip Sentinel that is used to establish a secret, authenticated handshake between your node and the Skip sentinel
+- For nodes that should not communicate with the sentinel directly (e.g. validator nodes that have sentries), this does not need to be set.
+- **⭐  You can find the correct version of the `relayer_conn_string` here:** [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c)
+
+### `api_key`
+
+- This is the unique string key Skip uses to ensure a node establishing a connection with our relay actually belongs to your validator.
+- If you don't have one, please request one from the Skip team on our **[discord](https://discord.gg/amAgf9Z39w)**
+
+### `validator_addr_hex`
+
+- This is the unique identifier of your validator node. See step 1 for how to find.
+
+### `**personal_peer_ids**`
+
+- **You only need to set this if you use sentries. If you run bare or use an offline signer, you can leave this as an empty string**
+- This is the list of peer nodes your node will gossip Skip bundles to after receiving them.
+    - For your validator, this should be the `p2p ids` of all your **sentry nodes**
+    - For your sentry nodes, this should be the `p2p ids` of all your **other** sentry nodes, **and your validator**
+- You can find a node’s p2p id using
+
+```json
+junod tendermint show-node --home <HOME_DIR>
+```
+
+## 4. Recompile your binary, and start! 🎉
+
+That’s it! After making the changes above, you can recompile your binary (e.g. `junod`, probably using `make install`),  and restart your node(s)! You will now begin receiving MEV bundles from Skip.
+
+---
+
+# 🤿 About `mev-tendermint`
+
+## ✅  Design Goals
 
 The design goals of MEV-Tendermint is to allow & preserve:
 
@@ -17,15 +132,15 @@ The design goals of MEV-Tendermint is to allow & preserve:
 5. 🔄  **On-chain transaction submission** via gossip, no need for off-chain submission like HTTP endpoints, endpoint querying, etc
 6. 💨  **Impossible to slow down block time**, i.e. no part of mev-tendermint introduces consensus delays
 
-### Basic Functionality Overview
+## 🔎  Basic Functionality Overview
 
-🏦 **Auction**
+🏦  **Auction**
 
 - Prior to the creation of the first proposal for height `n+1` , the Skip Sentinel infrastructure selects an auction-winning bundle (or bundles) to include at the top of block `n+1`
 - The auction-winning bundle is defined as the bundle that pays the highest gas price ( sum(txFee)/sum(gasWanted) ) and doesn’t include any reverting transactions
 - The sentinel ensures it’s simulations of the bundle are accurate by simulating it against the version of state where it will actually run (by optimistically applying the proposals produced for height `n` )
 
-🗣️ **Gossip**
+🗣️  **Gossip**
 
 - Before the first proposal for height `n+1` is created, the Skip sentinel gossips the auction-winning bundle(s) to whichever nodes belonging to that proposer it can access (e.g. sentries if the validator is using a sentry configuration, or validator replicas if it’s using horcrux)
 - The nodes that receive the winning bundle(s) gossip it to the other nodes belonging to that proposer to ensure the bundle(s) reach the validator
@@ -33,7 +148,7 @@ The design goals of MEV-Tendermint is to allow & preserve:
 
 [reinforce that we have different channels on the same reactor]
 
-🏒 **Handling Transactions**
+🏒  **Handling Transactions**
 
 - Ordinary transactions received over traditional gossip are handled exactly the same way they are today in the mempool
 - Transactions received as part of bundles sent from the Skip sentinel are handled and stored in a new data structure called the `sidecar`
@@ -41,16 +156,16 @@ The design goals of MEV-Tendermint is to allow & preserve:
 
 [reinforce that we have a new transaction data structure]
 
-🚜 **Reaping** 
+🚜  **Reaping** 
 
 - On reap, mev-tendermint first checks whether there are any fully-constructed bundles in the sidecar then reaps these first.
 - Next, it reaps from the ordinary mempool, with some additional checks to ensure that transactions reaped from the sidecar don’t get reaped again if they are also present in the standard mempool
 
 [reinforce reaping of bundle goes to top if available]
 
-### Components
+## 🧱 Components
 
-**#1 The Sidecar**
+### **#1 The Sidecar**
 
 - A separate, private mempool that respects `bundles` of transactions
     - Relevant files: `mempool/clist_sidecar.go`
@@ -78,43 +193,20 @@ The design goals of MEV-Tendermint is to allow & preserve:
 - The regular mempool now considers `sidecarTxs` (i.e. bundles) in addition to regular txs, and orders the former before the latter
     - Relevant files: `mempool/clist_mempool.go`, `state/execution.go`
 
-# 👨‍💻 How to Configure
+---
 
-### 1. Tendermint replacement ♻️
+## ䷾ Metrics
 
-In the `go.mod` file of the directory you use to compile your chain binary, you need to `replace` the imported version of `tendermint` with the correct `mev-tendermint` version, like so:
+`mev-tendermint` exposes new **[prometheus metrics](https://docs.tendermint.com/v0.34/tendermint-core/metrics.html)** that you can use to supplement your dashboards (e.g. with Grafana)
 
-- For Juno (testnet and mainnet), this is: `github.com/skip-mev/mev-tendermint/v0.34.21-mev.1`
+**Metrics exposed:**
 
-```tsx
-// ---------------------------------
-replace (
-	// Other stuff...
-	github.com/tendermint/tendermint => github.com/skip-mev/mev-tendermint v0.34.21-mev.1
-)
-```
-
-🚨 **After modifying the `replace` statement, run `go mod tidy` in your base directory**
-
-### 2. Peering Setup 🤝
-
-mev-tendermint introduces a new section of config in `config.toml` called `sidecar`, which contains 2 settings that you must configure in order to receive bundles from the skip sentinel: 
-
-- `relayer_conn_string` : This is the Tendermint p2p peer string (`id@ip:port`) of the Skip Sentinel that is used to establish a secret, authenticated handshake between your node and the Skip relayer
-    - For nodes that should not communicate with the relayer directly (e.g. validator nodes that have sentries), this does not need to be set.
-- `personal_peer_ids`: These are the Tendermint p2p ids of all the nodes that your node will gossip side car transactions with. To ensure trader privacy, these should only include p2p ids of nodes that you manage.
-    - For your validator, this should be the `ids` of all your sentry nodes
-    - For your sentry nodes, this should be the `ids` of all your **other** sentry nodes, and your validator
-- `validator_addr_hex`: The hex associated with your validator address. This tells the relayer to fire to this node when this validator is the block proposer.
-- `api_key`: The API key issued to you, associated with your validator hex. Used for sending a peer registration request to the relayer.
-
-### 3. Information Skip Requires from you  ℹ️
-
-In order to participate in the network, you must share with Skip (feel free to contact us at on our **[website](https://skip.money/)**): 
-
-1. The Tendermint Address of your validator (The `“address”` field of the `priv_validator_key.json` file generated by Tendermint)
-2. The Tendermint p2p ids of all nodes you wish the Skip sentinel to gossip with directly (Can be obtained by `tendermint show-node-id`
-
-### 4. Recompile your binary, and start! 🎉
-
-That’s it! After making the changes above, you can recompile your binary like `junod` (probably using `make install`),  and restart your node(s)! You will now begin receiving MEV bundles from Skip.
+| Name | Type | Description |
+| --- | --- | --- |
+| sidecar_size_bytes | Histogram | Histogram of sidecar mev transaction sizes, in bytes |
+| sidecar_size | Gauge | Size of the sidecar |
+| num_bundles_total | Counter | Number of MEV bundles received by the sidecar in total |
+| num_bundles_last_block | Gauge | Number of mev bundles received during the last block |
+| num_mev_txs_total | Counter | Number of mev transactions added in total |
+| num_mev_txs_last_block | Gauge | Number of mev transactions received by sidecar in the last block |
+| relay_connected | Gauge | Whether or not a node is connected to the relay, 1 if connected, 0 if not. |

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -80,7 +80,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				state.LastBlockHeight,
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight)
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -80,7 +80,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				state.LastBlockHeight,
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), nil)
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -410,7 +410,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -410,7 +410,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight)
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -174,7 +174,7 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv0.WithMetrics(memplMetrics),
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -174,7 +174,7 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv0.WithMetrics(memplMetrics),
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight)
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -115,39 +115,39 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 		SidecarSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_size",
+			Name:      "size",
 			Help:      "Size of the sidecar (number of uncommitted transactions).",
 		}, labels).With(labelsAndValues...),
 		SidecarTxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_size_bytes",
+			Name:      "size_bytes",
 			Help:      "MEV transaction sizes in bytes.",
 		}, labels).With(labelsAndValues...),
 
 		NumBundlesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_num_bundles_total",
+			Name:      "num_bundles_total",
 			Help:      "Number of MEV bundles received by the sidecar in total.",
 		}, labels).With(labelsAndValues...),
 		NumBundlesLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_num_bundles_last_block",
+			Name:      "num_bundles_last_block",
 			Help:      "Number of MEV bundles received by the sidecar in the last block.",
 		}, labels).With(labelsAndValues...),
 
 		NumMevTxsTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_num_mev_txs_total",
+			Name:      "num_mev_txs_total",
 			Help:      "Number of MEV transactions received to the sidecar in total.",
 		}, labels).With(labelsAndValues...),
 		NumMevTxsLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: SidecarMetricsSubsystem,
-			Name:      "sidecar_num_mev_txs_last_block",
+			Name:      "num_mev_txs_last_block",
 			Help:      "Number of MEV transactions received to the sidecar in the last block.",
 		}, labels).With(labelsAndValues...),
 	}

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -10,7 +10,8 @@ import (
 const (
 	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
 	// package.
-	MetricsSubsystem = "mempool"
+	MetricsSubsystem        = "mempool"
+	SidecarMetricsSubsystem = "sidecar"
 )
 
 // Metrics contains metrics exposed by this package.
@@ -113,40 +114,40 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 		// SIDECAR METRICS
 		SidecarSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
+			Subsystem: SidecarMetricsSubsystem,
 			Name:      "sidecar_size",
 			Help:      "Size of the sidecar (number of uncommitted transactions).",
 		}, labels).With(labelsAndValues...),
 		SidecarTxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
+			Subsystem: SidecarMetricsSubsystem,
 			Name:      "sidecar_size_bytes",
 			Help:      "MEV transaction sizes in bytes.",
 		}, labels).With(labelsAndValues...),
 
 		NumBundlesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "num_bundles_total",
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "sidecar_num_bundles_total",
 			Help:      "Number of MEV bundles received by the sidecar in total.",
 		}, labels).With(labelsAndValues...),
 		NumBundlesLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "num_bundles_last_block",
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "sidecar_num_bundles_last_block",
 			Help:      "Number of MEV bundles received by the sidecar in the last block.",
 		}, labels).With(labelsAndValues...),
 
 		NumMevTxsTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "num_mev_txs_total",
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "sidecar_num_mev_txs_total",
 			Help:      "Number of MEV transactions received to the sidecar in total.",
 		}, labels).With(labelsAndValues...),
 		NumMevTxsLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "num_mev_txs_last_block",
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "sidecar_num_mev_txs_last_block",
 			Help:      "Number of MEV transactions received to the sidecar in the last block.",
 		}, labels).With(labelsAndValues...),
 	}

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -57,7 +57,7 @@ type CListMempool struct {
 	// This reduces the pressure on the proxyApp.
 	cache mempool.TxCache
 
-	logger  log.Logger
+	Logger  log.Logger
 	metrics *mempool.Metrics
 }
 
@@ -82,7 +82,7 @@ func NewCListMempool(
 		height:        height,
 		recheckCursor: nil,
 		recheckEnd:    nil,
-		logger:        log.NewNopLogger(),
+		Logger:        log.NewNopLogger(),
 		metrics:       mempool.NopMetrics(),
 	}
 
@@ -108,7 +108,7 @@ func (mem *CListMempool) EnableTxsAvailable() {
 
 // SetLogger sets the Logger.
 func (mem *CListMempool) SetLogger(l log.Logger) {
-	mem.logger = l
+	mem.Logger = l
 }
 
 // WithPreCheck sets a filter for the mempool to reject a tx if f(tx) returns
@@ -387,7 +387,7 @@ func (mem *CListMempool) resCbFirstTime(
 			if err := mem.isFull(len(tx)); err != nil {
 				// remove from cache (mempool might have a space later)
 				mem.cache.Remove(tx)
-				mem.logger.Error(err.Error())
+				mem.Logger.Error(err.Error())
 				return
 			}
 
@@ -398,7 +398,7 @@ func (mem *CListMempool) resCbFirstTime(
 			}
 			memTx.Senders.Store(peerID, true)
 			mem.addTx(memTx)
-			mem.logger.Debug(
+			mem.Logger.Debug(
 				"added good transaction",
 				"tx", types.Tx(tx).Hash(),
 				"res", r,
@@ -408,7 +408,7 @@ func (mem *CListMempool) resCbFirstTime(
 			mem.notifyTxsAvailable()
 		} else {
 			// ignore bad transaction
-			mem.logger.Debug(
+			mem.Logger.Debug(
 				"rejected bad transaction",
 				"tx", types.Tx(tx).Hash(),
 				"peerID", peerP2PID,
@@ -448,7 +448,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 				break
 			}
 
-			mem.logger.Error(
+			mem.Logger.Error(
 				"re-CheckTx transaction mismatch",
 				"got", types.Tx(tx),
 				"expected", memTx.Tx,
@@ -475,7 +475,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			// Good, nothing to do.
 		} else {
 			// Tx became invalidated due to newly committed block.
-			mem.logger.Debug("tx is no longer valid", "tx", types.Tx(tx).Hash(), "res", r, "err", postCheckErr)
+			mem.Logger.Debug("tx is no longer valid", "tx", types.Tx(tx).Hash(), "res", r, "err", postCheckErr)
 			// NOTE: we remove tx from the cache because it might be good later
 			mem.removeTx(tx, mem.recheckCursor, !mem.config.KeepInvalidTxsInCache)
 		}
@@ -486,7 +486,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 		}
 		if mem.recheckCursor == nil {
 			// Done!
-			mem.logger.Debug("done rechecking txs")
+			mem.Logger.Debug("done rechecking txs")
 
 			// incase the recheck removed all txs
 			if mem.Size() > 0 {
@@ -531,7 +531,7 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 	var sidecarTxsMap sync.Map
 
 	for _, scMemTx := range sidecarTxs {
-		mem.logger.Debug(
+		mem.Logger.Debug(
 			"reaped sidecar mev transaction",
 			"tx", types.Tx(scMemTx.Tx).Hash(),
 			"height", scMemTx.Height,
@@ -557,7 +557,7 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 
 		if _, ok := sidecarTxsMap.Load(memTx.Tx.Key()); ok {
 			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
-			mem.logger.Debug(
+			mem.Logger.Debug(
 				"skipped mempool tx, already found in sidecar",
 				"tx", types.Tx(memTx.Tx).Hash(),
 				"height", memTx.Height,
@@ -653,7 +653,7 @@ func (mem *CListMempool) Update(
 	// or just notify there're some txs left.
 	if mem.Size() > 0 {
 		if mem.config.Recheck {
-			mem.logger.Debug("recheck txs", "numtxs", mem.Size(), "height", height)
+			mem.Logger.Debug("recheck txs", "numtxs", mem.Size(), "height", height)
 			mem.recheckTxs()
 			// At this point, mem.txs are being rechecked.
 			// mem.recheckCursor re-scans mem.txs and possibly removes some txs.

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -85,7 +85,7 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CL
 
 	mp := NewCListMempool(cfg.Mempool, appConnMem, 0)
 	mp.SetLogger(log.TestingLogger())
-	sidecar := NewCListSidecar(0, log.NewNopLogger())
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 
 	return mp, sidecar, func() { os.RemoveAll(cfg.RootDir) }
 }

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -85,7 +85,7 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CL
 
 	mp := NewCListMempool(cfg.Mempool, appConnMem, 0)
 	mp.SetLogger(log.TestingLogger())
-	sidecar := NewCListSidecar(0)
+	sidecar := NewCListSidecar(0, log.NewNopLogger())
 
 	return mp, sidecar, func() { os.RemoveAll(cfg.RootDir) }
 }

--- a/mempool/v0/clist_sidecar.go
+++ b/mempool/v0/clist_sidecar.go
@@ -64,13 +64,14 @@ type Key struct {
 func NewCListSidecar(
 	height int64,
 	memLogger log.Logger,
+	memMetrics *mempool.Metrics,
 ) *CListPriorityTxSidecar {
 	sidecar := &CListPriorityTxSidecar{
 		txs:                    clist.New(),
 		height:                 height,
 		heightForFiringAuction: height + 1,
 		logger:                 memLogger,
-		metrics:                mempool.NopMetrics(),
+		metrics:                memMetrics,
 	}
 	sidecar.cache = mempool.NewLRUTxCache(10000)
 	return sidecar

--- a/mempool/v0/clist_sidecar.go
+++ b/mempool/v0/clist_sidecar.go
@@ -60,14 +60,16 @@ type Key struct {
 }
 
 // NewCListSidecar returns a new sidecar with the given configuration
+// takes in the logger for the mempool
 func NewCListSidecar(
 	height int64,
+	memLogger log.Logger,
 ) *CListPriorityTxSidecar {
 	sidecar := &CListPriorityTxSidecar{
 		txs:                    clist.New(),
 		height:                 height,
 		heightForFiringAuction: height + 1,
-		logger:                 log.NewNopLogger(),
+		logger:                 memLogger,
 		metrics:                mempool.NopMetrics(),
 	}
 	sidecar.cache = mempool.NewLRUTxCache(10000)

--- a/node/node.go
+++ b/node/node.go
@@ -408,11 +408,12 @@ func createMempoolAndSidecarAndMempoolReactor(
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)),
 		)
 
+		mp.SetLogger(logger)
+
 		sidecar := mempoolv0.NewCListSidecar(
 			state.LastBlockHeight,
+			logger,
 		)
-
-		mp.SetLogger(logger)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,

--- a/node/node.go
+++ b/node/node.go
@@ -413,6 +413,7 @@ func createMempoolAndSidecarAndMempoolReactor(
 		sidecar := mempoolv0.NewCListSidecar(
 			state.LastBlockHeight,
 			logger,
+			memplMetrics,
 		)
 
 		reactor := mempoolv0.NewReactor(

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -258,7 +258,7 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -366,7 +366,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -258,7 +258,7 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight)
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -366,7 +366,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight)
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger())
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -416,12 +416,12 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)),
 		)
 
+		mp.SetLogger(logger)
+
 		sidecar := mempoolv0.NewCListSidecar(
 			state.LastBlockHeight,
+			logger,
 		)
-
-		mp.SetLogger(logger)
-		mp.SetLogger(logger)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -421,6 +421,7 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 		sidecar := mempoolv0.NewCListSidecar(
 			state.LastBlockHeight,
 			logger,
+			memplMetrics,
 		)
 
 		reactor := mempoolv0.NewReactor(


### PR DESCRIPTION
Adding working prometheus metrics.

Relevant files include `mempool/metrics.go` where I added multiple new endpoints for alerting information about txs, bundles, and sizes for the sidecar.

Number of bundles is not shared by non-validator nodes, since they cannot decipher this information since they do not call reap.

In order to share logger and metrics space with the mempool, I used the same logger on startup for the sentinel that the mempool uses, and share the same metrics (see `node.go`)

