### PR TITLE
have the relayer with its own connection loop

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1086,11 +1086,11 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 // Sidecar defines configuration for gossiping the private sidecar
 // mempool among the relayer and the nodes that belong to a particular proposer
 type SidecarConfig struct {
-	RootDir             string `mapstructure:"home"`
-	RelayerConnString   string `mapstructure:"relayer_conn_string"`
-	PersonalPeerIDs     string `mapstructure:"personal_peer_ids"`
-	ValidatorAddrHex   string `mapstructure:"validator_addr_hex"`
-	APIKey              string `mapstructure:"api_key"`
+	RootDir           string `mapstructure:"home"`
+	RelayerConnString string `mapstructure:"relayer_conn_string"`
+	PersonalPeerIDs   string `mapstructure:"personal_peer_ids"`
+	ValidatorAddrHex  string `mapstructure:"validator_addr_hex"`
+	APIKey            string `mapstructure:"api_key"`
 }
 
 func DefaultSidecarConfig() *SidecarConfig {

--- a/node/node.go
+++ b/node/node.go
@@ -896,15 +896,14 @@ func NewNode(config *cfg.Config,
 	)
 
 	persistentPeers := splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " ")
-	if config.Sidecar.RelayerConnString != "" {
-		fmt.Println("[node startup]: Adding relayer as a persistent peer")
-		persistentPeers = append(persistentPeers, config.Sidecar.RelayerConnString)
-		// Add to persistent peers so we also dial
-		config.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
-	}
 	err = sw.AddPersistentPeers(persistentPeers)
 	if err != nil {
 		return nil, fmt.Errorf("could not add peers from persistent_peers field: %w", err)
+	}
+
+	err = sw.AddRelayerPeer(config.Sidecar.RelayerConnString)
+	if err != nil {
+		return nil, fmt.Errorf("could not add relayer from relayer_conn_string field: %w", err)
 	}
 
 	unconditionalPeerIDs := splitAndTrimEmpty(config.P2P.UnconditionalPeerIDs, ",", " ")

--- a/node/node.go
+++ b/node/node.go
@@ -1047,7 +1047,8 @@ func (n *Node) OnStart() error {
 	}
 
 	// Always connect to persistent peers
-	err = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
+	peersToDialOnStartup := append(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "), n.config.Sidecar.RelayerConnString)
+	err = n.sw.DialPeersAsync(peersToDialOnStartup)
 	if err != nil {
 		return fmt.Errorf("could not dial peers from persistent_peers field: %w", err)
 	}

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -495,6 +495,7 @@ func (r *Reactor) ensurePeers() {
 
 	// Dial picked addresses
 	for _, addr := range toDial {
+		toDial[r.Switch.RelayerNetAddr.ID] = r.Switch.RelayerNetAddr
 		go func(addr *p2p.NetAddress) {
 			err := r.dialPeer(addr)
 			if err != nil {
@@ -544,6 +545,7 @@ func (r *Reactor) dialAttemptsInfo(addr *p2p.NetAddress) (attempts int, lastDial
 }
 
 func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
+	fmt.Println("calling dialPeer for ", addr)
 	attempts, lastDialed := r.dialAttemptsInfo(addr)
 	if !r.Switch.IsPeerPersistent(addr) && attempts > maxAttemptsToDial {
 		r.book.MarkBad(addr, defaultBanTime)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -545,7 +545,6 @@ func (r *Reactor) dialAttemptsInfo(addr *p2p.NetAddress) (attempts int, lastDial
 }
 
 func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
-	fmt.Println("calling dialPeer for ", addr)
 	attempts, lastDialed := r.dialAttemptsInfo(addr)
 	if !r.Switch.IsPeerPersistent(addr) && attempts > maxAttemptsToDial {
 		r.book.MarkBad(addr, defaultBanTime)
@@ -563,7 +562,6 @@ func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 		}
 	}
 
-	fmt.Println("Dial within pex reactor", addr)
 	err := r.Switch.DialPeerWithAddress(addr)
 	if err != nil {
 		if _, ok := err.(p2p.ErrCurrentlyDialingOrExistingAddress); ok {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -561,6 +561,7 @@ func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 		}
 	}
 
+	fmt.Println("Dial within pex reactor", addr)
 	err := r.Switch.DialPeerWithAddress(addr)
 	if err != nil {
 		if _, ok := err.(p2p.ErrCurrentlyDialingOrExistingAddress); ok {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -495,7 +495,6 @@ func (r *Reactor) ensurePeers() {
 
 	// Dial picked addresses
 	for _, addr := range toDial {
-		toDial[r.Switch.RelayerNetAddr.ID] = r.Switch.RelayerNetAddr
 		go func(addr *p2p.NetAddress) {
 			err := r.dialPeer(addr)
 			if err != nil {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -371,7 +371,9 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 			}
 		}
 		go sw.reconnectToPeer(addr)
-	} else if peer.ID() == sw.RelayerNetAddr.ID {
+	}
+	fmt.Println("Looking to reconnect after StopPeerForError, peer ID is ", peer.ID(), "relayer id is ", sw.RelayerNetAddr.ID)
+	if peer.ID() == sw.RelayerNetAddr.ID {
 		fmt.Println("Relayer peer disconnected, attempting to reconnect")
 		var addr *NetAddress
 		var err error
@@ -813,6 +815,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 
 	// XXX(xla): Remove the leakage of test concerns in implementation.
 	if cfg.TestDialFail {
+		fmt.Println("looking to reconnectafter failed outboundPeerAttempt 1, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
 		if addr.ID == sw.RelayerNetAddr.ID {
 			go sw.reconnectToRelayerPeer(addr)
 			return fmt.Errorf("dial err relayer (peerConfig.DialFail == true)")
@@ -847,6 +850,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 		if sw.IsPeerPersistent(addr) {
 			go sw.reconnectToPeer(addr)
 		}
+		fmt.Println("looking to reconnect after failed outboundConfig 2, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
 		if addr.ID == sw.RelayerNetAddr.ID {
 			go sw.reconnectToRelayerPeer(addr)
 		}

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -416,15 +416,14 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 }
 
 func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
-	fmt.Println("STARTING RELAYER RECONNECT, addr is ", addr)
+	fmt.Println("[relayer-reconnection]: starting relayer reconnect routine, addr is ", addr)
 	if sw.reconnecting.Has(string(addr.ID)) {
+		fmt.Println("[relayer-reconnection]: already have a reconnection routine for ", addr)
 		return
 	}
 	sw.reconnecting.Set(string(addr.ID), addr)
 	defer sw.reconnecting.Delete(string(addr.ID))
 
-	// start := time.Now()
-	sw.Logger.Info("Reconnecting to relayer peer", "addr", addr)
 	i := 0
 	for {
 		if !sw.IsRunning() {
@@ -609,6 +608,10 @@ func (sw *Switch) dialPeersAsync(netAddrs []*NetAddress) {
 func (sw *Switch) DialPeerWithAddress(addr *NetAddress) error {
 	if sw.IsDialingOrExistingAddress(addr) {
 		return ErrCurrentlyDialingOrExistingAddress{addr.String()}
+	}
+
+	if addr.ID == sw.RelayerNetAddr.ID {
+		sw.Logger.Info("[relayer-reconnection]: DIALING RELAYER", "address", addr, "time", time.Now())
 	}
 
 	sw.dialing.Set(string(addr.ID), addr)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -666,6 +666,7 @@ func (sw *Switch) AddPersistentPeers(addrs []string) error {
 		}
 		return err
 	}
+	fmt.Println("[node startup]: setting persistent peers to ", netAddrs)
 	sw.persistentPeersAddrs = netAddrs
 	return nil
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -372,7 +372,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 		}
 		go sw.reconnectToPeer(addr)
 	}
-	fmt.Println("Looking to reconnect after StopPeerForError, peer ID is ", peer.ID(), "relayer id is ", sw.RelayerNetAddr.ID)
+	fmt.Println("Looking to reconnect after StopPeerForError, peer is ", peer, "relayer is ", sw.RelayerNetAddr)
 	if peer.ID() == sw.RelayerNetAddr.ID {
 		fmt.Println("Relayer peer disconnected, attempting to reconnect")
 		var addr *NetAddress
@@ -424,6 +424,7 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 }
 
 func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
+	fmt.Println("STARTING RELAYER RECONNECT, addr is ", addr)
 	if sw.reconnecting.Has(string(addr.ID)) {
 		return
 	}
@@ -540,7 +541,6 @@ func isPrivateAddr(err error) bool {
 // encounter is returned.
 // Nop if there are no peers.
 func (sw *Switch) DialPeersAsync(peers []string) error {
-	fmt.Println("DialPeersAsync for peers", peers)
 	netAddrs, errs := NewNetAddressStrings(peers)
 	// report all the errors
 	for _, err := range errs {
@@ -558,7 +558,6 @@ func (sw *Switch) DialPeersAsync(peers []string) error {
 }
 
 func (sw *Switch) dialPeersAsync(netAddrs []*NetAddress) {
-	fmt.Println("dialPeersAsync for peers", netAddrs)
 	ourAddr := sw.NetAddress()
 
 	// TODO: this code feels like it's in the wrong place.
@@ -818,7 +817,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 
 	// XXX(xla): Remove the leakage of test concerns in implementation.
 	if cfg.TestDialFail {
-		fmt.Println("looking to reconnectafter failed outboundPeerAttempt 1, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
+		fmt.Println("looking to reconnectafter failed outboundPeerAttempt 1, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr)
 		if addr.ID == sw.RelayerNetAddr.ID {
 			go sw.reconnectToRelayerPeer(addr)
 			return fmt.Errorf("dial err relayer (peerConfig.DialFail == true)")
@@ -852,10 +851,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 		// any dial error besides IsSelf()
 		if sw.IsPeerPersistent(addr) {
 			go sw.reconnectToPeer(addr)
-		} else {
-			fmt.Println("looking to reconnect after failed outboundConfig 2, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
-		}
-		if addr.ID == sw.RelayerNetAddr.ID {
+		} else if addr.ID == sw.RelayerNetAddr.ID {
 			go sw.reconnectToRelayerPeer(addr)
 		}
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -859,6 +859,8 @@ func (sw *Switch) addOutboundPeerWithConfig(
 			_ = p.Stop()
 		}
 		return err
+	} else if addr.ID == sw.RelayerNetAddr.ID {
+		sw.Logger.Info("[relayer-reconnection]: RELAYER RECONNECTED!", "address", addr)
 	}
 
 	return nil

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -540,6 +540,7 @@ func isPrivateAddr(err error) bool {
 // encounter is returned.
 // Nop if there are no peers.
 func (sw *Switch) DialPeersAsync(peers []string) error {
+	fmt.Println("DialPeersAsync for peers", peers)
 	netAddrs, errs := NewNetAddressStrings(peers)
 	// report all the errors
 	for _, err := range errs {
@@ -557,6 +558,7 @@ func (sw *Switch) DialPeersAsync(peers []string) error {
 }
 
 func (sw *Switch) dialPeersAsync(netAddrs []*NetAddress) {
+	fmt.Println("dialPeersAsync for peers", netAddrs)
 	ourAddr := sw.NetAddress()
 
 	// TODO: this code feels like it's in the wrong place.

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -375,15 +375,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	fmt.Println("Looking to reconnect after StopPeerForError, peer is ", peer, "relayer is ", sw.RelayerNetAddr)
 	if peer.ID() == sw.RelayerNetAddr.ID {
 		fmt.Println("Relayer peer disconnected, attempting to reconnect")
-		var addr *NetAddress
-		var err error
-		addr, err = peer.NodeInfo().NetAddress()
-		if err != nil {
-			sw.Logger.Error("Wanted to reconnect to inbound relayer, but self-reported address is wrong",
-				"peer", peer, "err", err)
-			return
-		}
-		go sw.reconnectToRelayerPeer(addr)
+		go sw.reconnectToRelayerPeer(sw.RelayerNetAddr)
 	}
 
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -440,7 +440,6 @@ func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
 		sw.Logger.Info("[relayer-connection]: Error reconnecting to relayer. Trying again", "tries", i, "err", err, "addr", addr)
 		// sleep a set amount
 		sw.randomSleep(30 * time.Second)
-		sw.Logger.Info("[relayer-connection]: queuing up another relayer connection", "try", i)
 		i++
 	}
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -437,7 +437,7 @@ func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
 			return
 		}
 
-		sw.Logger.Info("[relayer-connection]: Error reconnecting to relayer. Trying again", "tries", i, "err", err, "addr", addr)
+		sw.Logger.Info("[relayer-reconnection]: Error reconnecting to relayer. Trying again", "tries", i, "err", err, "addr", addr)
 		// sleep a set amount
 		sw.randomSleep(30 * time.Second)
 		i++

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -850,8 +850,9 @@ func (sw *Switch) addOutboundPeerWithConfig(
 		// any dial error besides IsSelf()
 		if sw.IsPeerPersistent(addr) {
 			go sw.reconnectToPeer(addr)
+		} else {
+			fmt.Println("looking to reconnect after failed outboundConfig 2, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
 		}
-		fmt.Println("looking to reconnect after failed outboundConfig 2, not persistent but addr is ", addr, "id is ", addr.ID, sw.RelayerNetAddr.ID)
 		if addr.ID == sw.RelayerNetAddr.ID {
 			go sw.reconnectToRelayerPeer(addr)
 		}


### PR DESCRIPTION
This patch puts the reconnection onus on peered nodes, that now dial the sentinel every 30 seconds if not connected.