### PR TITLE
[ENG-132] Unit tests for new mev-tendermint functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ test/fuzz/**/*.zip
 *.pdf
 *.gz
 *.dvi
+
+coverage.out

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -136,72 +136,6 @@ func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sideca
 	return txs
 }
 
-func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
-	totalTxsCount := 0
-	txs := make(types.Txs, 0)
-	for i := 0; i < numBundles; i++ {
-		totalTxsCount += int(bundleSize)
-		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
-			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
-		txs = append(txs, newTxs...)
-	}
-	return txs
-}
-
-func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
-
-	bInfo := testBundleInfo{BundleSize: int64(len(txs)), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
-	for i := 0; i < len(txs); i++ {
-		err := sidecar.AddTx(txs[i], mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
-			BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: int64(i)})
-		if err != nil {
-			t.Error(err)
-		}
-	}
-	return txs
-}
-
-func addNumTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
-
-	txs := make(types.Txs, numTxs)
-	bInfo := testBundleInfo{BundleSize: int64(numTxs), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
-	for i := 0; i < numTxs; i++ {
-		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
-		txs = append(txs, txBytes)
-	}
-	return txs
-}
-
-func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
-	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
-		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
-	txBytes := make([]byte, 20)
-	_, err := rand.Read(txBytes)
-	if err != nil {
-		t.Error(err)
-	}
-	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
-		fmt.Println("Ignoring error in AddTx:", err)
-	}
-	return txBytes
-}
-
-func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
-	txs := make(types.Txs, bInfo.BundleSize)
-	for i := 0; i < int(bInfo.BundleSize); i++ {
-		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
-		txs[i] = txBytes
-	}
-	return txs
-}
-
-func addBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bundles []testBundleInfo, peerID uint16) {
-	for _, bundle := range bundles {
-		// createSidecarBundleWithTxs(t, sidecar, bundle.BundleSize, peerID, bundle.BundleID, bundle.DesiredHeight)
-		createSidecarBundleAndTxs(t, sidecar, bundle)
-	}
-}
-
 func TestReapMaxBytesMaxGas(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
@@ -251,354 +185,53 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 	}
 }
 
-func TestBasicAddMultipleBundles(t *testing.T) {
+func TestReapMaxBytesMaxGas_ReapsSidecar(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
-	tests := []struct {
-		numBundlesTxsToCreate int
-	}{
-		{0},
-		{1},
-		{5},
-		{0},
-		{100},
+	// Make sidecar txes consisting of one tx
+	tx := tmrand.Bytes(20)
+	expectedTxs := make(types.Txs, 1)
+	expectedTxs[0] = tx
+	sidecarTxs := []*mempool.MempoolTx{
+		{
+			Height: 5,
+			GasWanted: 100,
+			Tx: tx,
+		},
 	}
-	for tcIndex, tt := range tests {
-		fmt.Println("Num bundles to create: ", tt.numBundlesTxsToCreate)
-		addNumBundlesToSidecar(t, sidecar, tt.numBundlesTxsToCreate, 10, mempool.UnknownPeerID)
-		sidecar.ReapMaxTxs()
-		assert.Equal(t, tt.numBundlesTxsToCreate, sidecar.NumBundles(), "Got %d bundles, expected %d, tc #%d",
-			sidecar.NumBundles(), tt.numBundlesTxsToCreate, tcIndex)
-		sidecar.Flush()
-	}
+
+	// Pass sidecar txes to reap
+	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
+
+	// Assert that it got reaped
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
 }
 
-func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
+func TestReapMaxBytesMaxGas_SkipsSidecarTxsInMempoolReap(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
-	// only one since no txs in first
-	{
-		// bundleSize, bundleHeight, bundleID, peerID
-		bundles := []testBundleInfo{
-			{0, 1, 0, 0},
-			{5, 1, 1, 0},
-		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
-		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
-			sidecar.NumBundles(), 1)
-		sidecar.Flush()
+	// Put one tx in the mempool
+	expectedTxs := checkTxs(t, mp, 1, mempool.UnknownPeerID, nil, false)
+	// Put the same tx in sidecarTxs
+	sidecarTxs := []*mempool.MempoolTx{
+		{
+			Height: 5,
+			GasWanted: 100,
+			Tx: expectedTxs[0],
+		},
 	}
 
-	// three bundles
-	{
-		// bundleSize, bundleHeight, bundleID, peerID
-		bundles := []testBundleInfo{
-			{5, 1, 0, 0},
-			{5, 5, 1, 0},
-			{5, 10, 1, 0},
-		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
-		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
-			sidecar.NumBundles(), 3)
-		sidecar.Flush()
-	}
+	// Reap
+	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
 
-	// only one bundle since we already have all these bundleOrders
-	{
-		// bundleSize, bundleHeight, bundleID, peerID
-		bundles := []testBundleInfo{
-			{5, 1, 0, 0},
-			{5, 1, 0, 0},
-			{5, 1, 0, 0},
-		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
-		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
-			sidecar.NumBundles(), 1)
-		sidecar.Flush()
-	}
-
-	// only one bundle since we already have all these bundleOrders
-	{
-		// bundleSize, bundleHeight, BundleID, peerID
-		bundles := []testBundleInfo{
-			{5, 1, 0, 0},
-			{5, 1, 3, 0},
-			{5, 1, 5, 0},
-		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
-		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
-			sidecar.NumBundles(), 3)
-		sidecar.Flush()
-	}
-}
-
-// TODO: shorten
-func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// 1. Inserted out of order, but sequential, but bundleSize 1, so should get one tx
-	{
-		bInfo := testBundleInfo{
-			BundleSize:    1,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		var bundleOrder int64 = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    1,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		sidecar.PrettyPrintBundles()
-
-		txs := sidecar.ReapMaxTxs()
-		assert.Equal(t, 1, len(txs), "Got %d txs, expected %d",
-			len(txs), 1)
-
-		sidecar.Flush()
-	}
-
-	// 2. Same as before but now size is open to 2, so expect 2
-	{
-		bInfo := testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		var bundleOrder int64 = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		txs := sidecar.ReapMaxTxs()
-		assert.Equal(t, 2, len(txs), "Got %d txs, expected %d",
-			len(txs), 2)
-
-		sidecar.Flush()
-	}
-
-	// 3. Insert a bundle out of order and non sequential, so nothing should happen
-	{
-		bInfo := testBundleInfo{
-			BundleSize:    5,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		var bundleOrder int64 = 3
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    5,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		txs := sidecar.ReapMaxTxs()
-		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
-			len(txs), 0)
-
-		sidecar.Flush()
-	}
-
-	// 4. Insert three successful bundles out of order
-	//nolint:dupl
-	{
-		bInfo := testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      2,
-		}
-		var bundleOrder int64 = 2
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      2,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      2,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		// ============
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		// ============
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      1,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      1,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		txs := sidecar.ReapMaxTxs()
-		assert.Equal(t, 7, len(txs), "Got %d txs, expected %d",
-			len(txs), 7)
-		sidecar.PrettyPrintBundles()
-
-		fmt.Println("TXS FROM REAP ----------")
-		for _, memTx := range txs {
-			fmt.Println(memTx.Tx.String())
-		}
-		fmt.Println("----------")
-
-		sidecar.Flush()
-	}
-
-	// 5. Multiple unsuccessful bundles, nothing reaped
-	//nolint:dupl
-	{
-		// size not filled
-		bInfo := testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      2,
-		}
-		var bundleOrder int64
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      2,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		// ============
-
-		// wrong orders
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 2
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 3
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		// ============
-
-		// wrong heights
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 2,
-			BundleID:      1,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 0,
-			BundleID:      1,
-		}
-		bundleOrder = 0
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		txs := sidecar.ReapMaxTxs()
-		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
-			len(txs), 0)
-		sidecar.PrettyPrintBundles()
-
-		fmt.Println("TXS FROM REAP ----------")
-		for _, memTx := range txs {
-			fmt.Println(memTx.Tx.String())
-		}
-		fmt.Println("----------")
-
-		sidecar.Flush()
-	}
-
+	// Assert that it only got reaped once
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
 }
 
 func TestMempoolFilters(t *testing.T) {
@@ -675,41 +308,6 @@ func TestMempoolUpdate(t *testing.T) {
 
 		err = mp.CheckTx([]byte{0x03}, nil, mempool.TxInfo{})
 		require.NoError(t, err)
-	}
-}
-
-func TestSidecarUpdate(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// 1. Flushes the sidecar
-	{
-		bInfo := testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		var bundleOrder int64
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		bInfo = testBundleInfo{
-			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
-			DesiredHeight: 1,
-			BundleID:      0,
-		}
-		bundleOrder = 1
-		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
-
-		err := sidecar.Update(0, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
-		require.NoError(t, err)
-		require.Equal(t, 2, sidecar.Size(), "foo with a newline should be written")
-		err = sidecar.Update(1, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
-		require.NoError(t, err)
-		require.Equal(t, 0, sidecar.Size(), "foo with a newline should be written")
 	}
 }
 
@@ -857,45 +455,6 @@ func TestTxsAvailable(t *testing.T) {
 	checkTxs(t, mp, 100, mempool.UnknownPeerID, nil, false)
 	ensureFire(t, mp.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
-}
-
-func TestSidecarTxsAvailable(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-	sidecar.EnableTxsAvailable()
-
-	timeoutMS := 500
-
-	// with no txs, it shouldnt fire
-	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
-
-	// send a bunch of txs, it should only fire once
-	txs := addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
-	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
-	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
-
-	// call update with half the txs.
-	// it should fire once now for the new height
-	// since there are still txs left
-	txs = txs[50:]
-
-	// send a bunch more txs. we already fired for this height so it shouldnt fire again
-	moreTxs := addNumBundlesToSidecar(t, sidecar, 50, 10, mempool.UnknownPeerID)
-	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
-
-	// now call update with all the txs. it should not fire as there are no txs left
-	committedTxs := append(txs, moreTxs...) //nolint: gocritic
-	if err := sidecar.Update(2, committedTxs, abciResponses(len(committedTxs), abci.CodeTypeOK)); err != nil {
-		t.Error(err)
-	}
-	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
-
-	// send a bunch more txs, it should only fire once
-	addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
-	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
-	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 }
 
 func TestSerialReap(t *testing.T) {

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -197,9 +197,9 @@ func TestReapMaxBytesMaxGas_ReapsSidecar(t *testing.T) {
 	expectedTxs[0] = tx
 	sidecarTxs := []*mempool.MempoolTx{
 		{
-			Height: 5,
+			Height:    5,
 			GasWanted: 100,
-			Tx: tx,
+			Tx:        tx,
 		},
 	}
 
@@ -221,9 +221,9 @@ func TestReapMaxBytesMaxGas_SkipsSidecarTxsInMempoolReap(t *testing.T) {
 	// Put the same tx in sidecarTxs
 	sidecarTxs := []*mempool.MempoolTx{
 		{
-			Height: 5,
+			Height:    5,
 			GasWanted: 100,
-			Tx: expectedTxs[0],
+			Tx:        expectedTxs[0],
 		},
 	}
 

--- a/mempool/v0/clist_sidecar_test.go
+++ b/mempool/v0/clist_sidecar_test.go
@@ -1,0 +1,534 @@
+package v0
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tendermint/abci/example/kvstore"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/mempool"
+	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/types"
+)
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
+	bInfo := testBundleInfo{BundleSize: int64(len(txs)), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
+	for i := 0; i < len(txs); i++ {
+		err := sidecar.AddTx(txs[i], mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+			BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: int64(i)})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return txs
+}
+
+func addNumTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
+	txs := make(types.Txs, numTxs)
+	bInfo := testBundleInfo{BundleSize: int64(numTxs), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
+	for i := 0; i < numTxs; i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs = append(txs, txBytes)
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bundles []testBundleInfo, peerID uint16) {
+	for _, bundle := range bundles {
+		// createSidecarBundleWithTxs(t, sidecar, bundle.BundleSize, peerID, bundle.BundleID, bundle.DesiredHeight)
+		createSidecarBundleAndTxs(t, sidecar, bundle)
+	}
+}
+
+func TestSidecarUpdate(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// 1. Flushes the sidecar
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		err := sidecar.Update(0, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
+		require.NoError(t, err)
+		require.Equal(t, 2, sidecar.Size(), "foo with a newline should be written")
+		err = sidecar.Update(1, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
+		require.NoError(t, err)
+		require.Equal(t, 0, sidecar.Size(), "foo with a newline should be written")
+	}
+}
+
+func TestSidecarTxsAvailable(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+	sidecar.EnableTxsAvailable()
+
+	timeoutMS := 500
+
+	// with no txs, it shouldnt fire
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// send a bunch of txs, it should only fire once
+	txs := addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// call update with half the txs.
+	// it should fire once now for the new height
+	// since there are still txs left
+	txs = txs[50:]
+
+	// send a bunch more txs. we already fired for this height so it shouldnt fire again
+	moreTxs := addNumBundlesToSidecar(t, sidecar, 50, 10, mempool.UnknownPeerID)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// now call update with all the txs. it should not fire as there are no txs left
+	committedTxs := append(txs, moreTxs...) //nolint: gocritic
+	if err := sidecar.Update(2, committedTxs, abciResponses(len(committedTxs), abci.CodeTypeOK)); err != nil {
+		t.Error(err)
+	}
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// send a bunch more txs, it should only fire once
+	addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+}
+
+// TODO: shorten
+func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// 1. Inserted out of order, but sequential, but bundleSize 1, so should get one tx
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    1,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    1,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		sidecar.PrettyPrintBundles()
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 1, len(txs), "Got %d txs, expected %d",
+			len(txs), 1)
+
+		sidecar.Flush()
+	}
+
+	// 2. Same as before but now size is open to 2, so expect 2
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 2, len(txs), "Got %d txs, expected %d",
+			len(txs), 2)
+
+		sidecar.Flush()
+	}
+
+	// 3. Insert a bundle out of order and non sequential, so nothing should happen
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    5,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 3
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    5,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
+			len(txs), 0)
+
+		sidecar.Flush()
+	}
+
+	// 4. Insert three successful bundles out of order
+	//nolint:dupl
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		var bundleOrder int64 = 2
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      1,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      1,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 7, len(txs), "Got %d txs, expected %d",
+			len(txs), 7)
+		sidecar.PrettyPrintBundles()
+
+		fmt.Println("TXS FROM REAP ----------")
+		for _, memTx := range txs {
+			fmt.Println(memTx.Tx.String())
+		}
+		fmt.Println("----------")
+
+		sidecar.Flush()
+	}
+
+	// 5. Multiple unsuccessful bundles, nothing reaped
+	//nolint:dupl
+	{
+		// size not filled
+		bInfo := testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		var bundleOrder int64
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		// wrong orders
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 2
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 3
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		// wrong heights
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 2,
+			BundleID:      1,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 0,
+			BundleID:      1,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
+			len(txs), 0)
+		sidecar.PrettyPrintBundles()
+
+		fmt.Println("TXS FROM REAP ----------")
+		for _, memTx := range txs {
+			fmt.Println(memTx.Tx.String())
+		}
+		fmt.Println("----------")
+
+		sidecar.Flush()
+	}
+}
+
+func TestBasicAddMultipleBundles(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	tests := []struct {
+		numBundlesTxsToCreate int
+	}{
+		{0},
+		{1},
+		{5},
+		{0},
+		{100},
+	}
+	for tcIndex, tt := range tests {
+		fmt.Println("Num bundles to create: ", tt.numBundlesTxsToCreate)
+		addNumBundlesToSidecar(t, sidecar, tt.numBundlesTxsToCreate, 10, mempool.UnknownPeerID)
+		sidecar.ReapMaxTxs()
+		assert.Equal(t, tt.numBundlesTxsToCreate, sidecar.NumBundles(), "Got %d bundles, expected %d, tc #%d",
+			sidecar.NumBundles(), tt.numBundlesTxsToCreate, tcIndex)
+		sidecar.Flush()
+	}
+}
+
+
+func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// only one since no txs in first
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{0, 1, 0, 0},
+			{5, 1, 1, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 1)
+		sidecar.Flush()
+	}
+
+	// three bundles
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 5, 1, 0},
+			{5, 10, 1, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 3)
+		sidecar.Flush()
+	}
+
+	// only one bundle since we already have all these bundleOrders
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 1, 0, 0},
+			{5, 1, 0, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 1)
+		sidecar.Flush()
+	}
+
+	// only one bundle since we already have all these bundleOrders
+	{
+		// bundleSize, bundleHeight, BundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 1, 3, 0},
+			{5, 1, 5, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 3)
+		sidecar.Flush()
+	}
+}
+
+func TestGetEnforcedBundleSize(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	assert.Equal(t, 0, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 0, sidecar.GetEnforcedBundleSize(0))
+
+	bundles := []testBundleInfo{
+		{5, 1, 0, 0},
+	}
+	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	assert.Equal(t, 5, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 5, sidecar.GetEnforcedBundleSize(0))
+}
+
+func TestGetCurrBundleSize(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	assert.Equal(t, 0, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 0, sidecar.GetCurrBundleSize(0))
+
+	bundles := []testBundleInfo{
+		{5, 1, 0, 0},
+	}
+	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	assert.Equal(t, 5, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 5, sidecar.GetCurrBundleSize(0))
+}

--- a/mempool/v0/clist_sidecar_test.go
+++ b/mempool/v0/clist_sidecar_test.go
@@ -440,7 +440,6 @@ func TestBasicAddMultipleBundles(t *testing.T) {
 	}
 }
 
-
 func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)

--- a/p2p/sentinel.go
+++ b/p2p/sentinel.go
@@ -26,7 +26,9 @@ func postRequestRoutine(logger log.Logger, sentinel string, jsonData []byte) {
 		logger.Info("[p2p.sentinel]: Err making post request to sentinel:", err)
 	} else {
 		logger.Info("[p2p.sentinel]: Successfully registered with sentinel", resp)
-		defer resp.Body.Close()
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
 	}
 }
 

--- a/p2p/sentinel.go
+++ b/p2p/sentinel.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -12,6 +11,26 @@ import (
 func RegisterWithSentinel(logger log.Logger, APIKey, validatorAddrHex, peerID, sentinel string) {
 	logger.Info("[p2p.sentinel]: Registering with sentinel", APIKey, validatorAddrHex, peerID, sentinel)
 
+	jsonData, err := makePostRequestData(APIKey, validatorAddrHex, peerID)
+	if err != nil {
+		logger.Info("[p2p.sentinel]: Err marshalling json data:", err)
+		return
+	}
+
+	go postRequestRoutine(logger, sentinel, jsonData)
+}
+
+func postRequestRoutine(logger log.Logger, sentinel string, jsonData []byte) {
+	resp, err := http.Post(sentinel, "application/json", bytes.NewBuffer(jsonData)) //nolint:gosec
+	if err != nil {
+		logger.Info("[p2p.sentinel]: Err making post request to sentinel:", err)
+	} else {
+		logger.Info("[p2p.sentinel]: Successfully registered with sentinel", resp)
+		defer resp.Body.Close()
+	}
+}
+
+func makePostRequestData(APIKey, validatorAddrHex, peerID string) ([]byte, error) {
 	params := [3]string{APIKey, validatorAddrHex, peerID}
 	data := map[string]interface{}{
 		"method": "register_peer",
@@ -19,19 +38,5 @@ func RegisterWithSentinel(logger log.Logger, APIKey, validatorAddrHex, peerID, s
 		"id":     1,
 	}
 
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		fmt.Println("[p2p.sentinel]: Err marshalling json data:", err)
-		return
-	}
-
-	go func() {
-		resp, err := http.Post(sentinel, "application/json", bytes.NewBuffer(jsonData)) //nolint:gosec
-		if err != nil {
-			logger.Info("[p2p.sentinel]: Err making post request to sentinel:", err)
-		} else {
-			logger.Info("[p2p.sentinel]: Successfully registered with sentinel", resp)
-			defer resp.Body.Close()
-		}
-	}()
+	return json.Marshal(data)
 }

--- a/p2p/sentinel_test.go
+++ b/p2p/sentinel_test.go
@@ -52,3 +52,20 @@ func TestPostRequestRoutine(t *testing.T) {
 	jsonData, _ := makePostRequestData("test-api-key", "ABCD1234", "a1b2c3d4")
 	postRequestRoutine(log.NewNopLogger(), server.URL, jsonData)
 }
+
+func TestPostRequestRoutine_DoesNotPanicOn500(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexpected panic from postRequestRoutine")
+		}
+	}()
+
+	// Make a mock http server to receive the register request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	jsonData, _ := makePostRequestData("test-api-key", "ABCD1234", "a1b2c3d4")
+	postRequestRoutine(log.NewNopLogger(), server.URL, jsonData)
+}

--- a/p2p/sentinel_test.go
+++ b/p2p/sentinel_test.go
@@ -1,0 +1,50 @@
+package p2p
+
+import (
+	"encoding/json"
+	"github.com/tendermint/tendermint/libs/log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPostRequestRoutine(t *testing.T) {
+	// Make a mock http server to receive the register request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.URL.Path != "/" {
+			t.Errorf("Expected to request '/', got: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Accept: application/json header, got: %s", r.Header.Get("Accept"))
+		}
+
+		bodyBytes := make([]byte, 100)
+		n, _ := r.Body.Read(bodyBytes)
+
+		var body map[string]interface{}
+		json.Unmarshal(bodyBytes[:n], &body)
+
+		if id := body["id"].(float64); id != float64(1) {
+			t.Errorf("Expected post body to have id=%f, got %f", float64(1), id)
+		}
+		if method := body["method"].(string); method != "register_peer" {
+			t.Errorf("Expected post body to have method=%s, got %s", "register_peer", method)
+		}
+		params := body["params"].([]interface{})
+		if apikey := params[0].(string); apikey != "test-api-key" {
+			t.Errorf("Expected post body params to have apikey %s, got %s", "test-api-key", apikey)
+		}
+		if valhex := params[1].(string); valhex != "ABCD1234" {
+			t.Errorf("Expected post body params to have valhex %s, got %s", "ABCD1234", valhex)
+		}
+		if peerID := params[2].(string); peerID != "a1b2c3d4" {
+			t.Errorf("Expected post body params to have peerID %s, got %s", "a1b2c3d4", peerID)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	jsonData, _ := makePostRequestData("test-api-key", "ABCD1234", "a1b2c3d4")
+	postRequestRoutine(log.NewNopLogger(), server.URL, jsonData)
+}

--- a/p2p/sentinel_test.go
+++ b/p2p/sentinel_test.go
@@ -2,10 +2,11 @@ package p2p
 
 import (
 	"encoding/json"
-	"github.com/tendermint/tendermint/libs/log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestPostRequestRoutine(t *testing.T) {
@@ -23,7 +24,10 @@ func TestPostRequestRoutine(t *testing.T) {
 		n, _ := r.Body.Read(bodyBytes)
 
 		var body map[string]interface{}
-		json.Unmarshal(bodyBytes[:n], &body)
+		err := json.Unmarshal(bodyBytes[:n], &body)
+		if err != nil {
+			t.Errorf("Erred while unmarshalling body: %s", err)
+		}
 
 		if id := body["id"].(float64); id != float64(1) {
 			t.Errorf("Expected post body to have id=%f, got %f", float64(1), id)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -857,4 +857,8 @@ func TestAddRelayerPeer(t *testing.T) {
 	}
 
 	assert.Equal(t, relayerNetAddr, sw.RelayerNetAddr, "Expected RelayerNetAddr %s, got %s", relayerNetAddr, sw.RelayerNetAddr)
+
+	errRelayerString := "abcd@1.2.3.4:26656"
+	err = sw.AddRelayerPeer(errRelayerString)
+	assert.True(t, err != nil, "Expected err with invalid relayer string")
 }

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -845,3 +845,13 @@ func BenchmarkSwitchBroadcast(b *testing.B) {
 
 	b.Logf("success: %v, failure: %v", numSuccess, numFailure)
 }
+
+func TestAddRelayerPeer(t *testing.T) {
+	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
+	relayerString := "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656"
+	relayerNetAddr, _ := NewNetAddressString(relayerString)
+
+	sw.AddRelayerPeer(relayerString)
+
+	assert.Equal(t, relayerNetAddr, sw.RelayerNetAddr, "Expected RelayerNetAddr %s, got %s", relayerNetAddr, sw.RelayerNetAddr)
+}

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -851,7 +851,10 @@ func TestAddRelayerPeer(t *testing.T) {
 	relayerString := "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656"
 	relayerNetAddr, _ := NewNetAddressString(relayerString)
 
-	sw.AddRelayerPeer(relayerString)
+	err := sw.AddRelayerPeer(relayerString)
+	if err != nil {
+		t.Errorf("Err in AddRelayerPeer: %s", err)
+	}
 
 	assert.Equal(t, relayerNetAddr, sw.RelayerNetAddr, "Expected RelayerNetAddr %s, got %s", relayerNetAddr, sw.RelayerNetAddr)
 }


### PR DESCRIPTION
`mempool/v0/clist_mempool.go`:
- Added test that sidecar gets reaped first
- Added test that txes in sidecar don't get reaped again in mempool reap

`mempool/v0/clist_sidecar.go`:
- Moved sidecar-specific tests to their own file
- Added test for `GetEnforcedBundleSize`
- Added test for `GetCurrBundleSize`

`p2p/sentinel.go`:
- Slight refactor for testability: building json data for post data moved to separate function. goroutine for making post request moved to separate function
- Added test that json body gets formed properly and goroutine makes post request with correct data to the expected endpoint

`p2p/switch.go`:
- Added test for AddRelayerPeer