### PR TITLE
[ENG-211] Add sidecar support for v1 mempool

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -71,7 +71,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
-		var sidecar mempl.PriorityTxSidecar
+		sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), mempl.NopMetrics())
 
 		switch thisConfig.Mempool.Version {
 		case cfg.MempoolV0:
@@ -80,7 +80,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				state.LastBlockHeight,
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), mempl.NopMetrics())
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -89,7 +88,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
-			sidecar = nil
 		}
 
 		if thisConfig.Consensus.WaitForTxs() {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -400,7 +400,7 @@ func newStateWithConfigAndBlockStore(
 
 	// Make Mempool
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -410,7 +410,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
+		
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,
@@ -421,7 +421,6 @@ func newStateWithConfigAndBlockStore(
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -410,7 +410,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		
+
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -173,8 +173,8 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1)
-			if len(txs.Txs) == 0 {
+			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1).Txs
+			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return
 			}

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -173,8 +173,8 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, nil)
-			if len(txs) == 0 {
+			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1)
+			if len(txs.Txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return
 			}

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -164,7 +164,7 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
-		var sidecar mempl.PriorityTxSidecar
+		sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 		switch config.Mempool.Version {
 		case cfg.MempoolV0:
@@ -174,7 +174,6 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv0.WithMetrics(memplMetrics),
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -184,7 +183,6 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
-			sidecar = nil
 		}
 		if thisConfig.Consensus.WaitForTxs() {
 			mempool.EnableTxsAvailable()

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -27,8 +27,8 @@ func (txmp emptyMempool) RemoveTxByKey(txKey types.TxKey) error {
 	return nil
 }
 
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
-	return types.Txs{}
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs {
+	return types.ReapedTxs{}
 }
 func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
@@ -59,7 +59,7 @@ type emptySidecar struct{}
 var _ mempl.PriorityTxSidecar = emptySidecar{}
 
 func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
-func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+func (emptySidecar) ReapMaxTxs() types.ReapedTxs            { return types.ReapedTxs{} }
 
 func (emptySidecar) Lock()   {}
 func (emptySidecar) Unlock() {}

--- a/mempool/clist_sidecar.go
+++ b/mempool/clist_sidecar.go
@@ -1,4 +1,4 @@
-package v0
+package mempool
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 	"github.com/tendermint/tendermint/libs/clist"
 	"github.com/tendermint/tendermint/libs/log"
 	tmsync "github.com/tendermint/tendermint/libs/sync"
-	"github.com/tendermint/tendermint/mempool"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -49,14 +48,14 @@ type CListPriorityTxSidecar struct {
 
 	// Keep a cache of already-seen txs.
 	// This reduces the pressure on the proxyApp.
-	cache mempool.TxCache
+	cache TxCache
 
 	logger log.Logger
 
-	metrics *mempool.Metrics
+	metrics *Metrics
 }
 
-var _ mempool.PriorityTxSidecar = &CListPriorityTxSidecar{}
+var _ PriorityTxSidecar = &CListPriorityTxSidecar{}
 
 type Key struct {
 	height, bundleID int64
@@ -67,7 +66,7 @@ type Key struct {
 func NewCListSidecar(
 	height int64,
 	memLogger log.Logger,
-	memMetrics *mempool.Metrics,
+	memMetrics *Metrics,
 ) *CListPriorityTxSidecar {
 	sidecar := &CListPriorityTxSidecar{
 		txs:                    clist.New(),
@@ -76,7 +75,7 @@ func NewCListSidecar(
 		logger:                 memLogger,
 		metrics:                memMetrics,
 	}
-	sidecar.cache = mempool.NewLRUTxCache(10000)
+	sidecar.cache = NewLRUTxCache(10000)
 	return sidecar
 }
 
@@ -85,7 +84,7 @@ func (sc *CListPriorityTxSidecar) PrettyPrintBundles() {
 	for bundleIDIter := 0; bundleIDIter <= int(sc.maxBundleID); bundleIDIter++ {
 		bundleIDIter := int64(bundleIDIter)
 		if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleIDIter}); ok {
-			bundle := bundle.(*mempool.Bundle)
+			bundle := bundle.(*Bundle)
 			fmt.Printf("BUNDLE ID: %d\n", bundleIDIter)
 
 			innerOrderMap := bundle.OrderedTxsMap
@@ -94,7 +93,7 @@ func (sc *CListPriorityTxSidecar) PrettyPrintBundles() {
 				bundleOrderIter := int64(bundleOrderIter)
 
 				if scTx, ok := innerOrderMap.Load(bundleOrderIter); ok {
-					scTx := scTx.(*mempool.SidecarTx)
+					scTx := scTx.(*SidecarTx)
 					fmt.Printf("---> ORDER %d: %s\n", bundleOrderIter, scTx.Tx)
 				}
 			}
@@ -131,7 +130,7 @@ func (sc *CListPriorityTxSidecar) notifyTxsAvailable() {
 
 //--------------------------------------------------------------------------------
 
-func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) error {
+func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo TxInfo) error {
 
 	sc.updateMtx.RLock()
 	// use defer to unlock mutex because application (*local client*) might panic
@@ -153,14 +152,14 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 		// Record a new sender for a tx we've already seen.
 
 		if e, ok := sc.txsMap.Load(tx.Key()); ok {
-			scTx := e.(*clist.CElement).Value.(*mempool.SidecarTx)
+			scTx := e.(*clist.CElement).Value.(*SidecarTx)
 			scTx.Senders.LoadOrStore(txInfo.SenderID, true)
 		}
 
-		return mempool.ErrTxInCache
+		return ErrTxInCache
 	}
 
-	scTx := &mempool.SidecarTx{
+	scTx := &SidecarTx{
 		DesiredHeight: txInfo.DesiredHeight,
 		Tx:            tx,
 		BundleID:      txInfo.BundleID,
@@ -184,7 +183,7 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 			"bundleOrder", txInfo.BundleOrder,
 			"tx", tx.Hash(),
 		)
-		return mempool.ErrWrongHeight{
+		return ErrWrongHeight{
 			DesiredHeight:        int(txInfo.DesiredHeight),
 			CurrentAuctionHeight: int(sc.heightForFiringAuction),
 		}
@@ -200,7 +199,7 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 			"bundleSize", txInfo.BundleSize,
 			"tx", tx.Hash(),
 		)
-		return mempool.ErrTxMalformedForBundle{
+		return ErrTxMalformedForBundle{
 			BundleID:     txInfo.BundleID,
 			BundleSize:   txInfo.BundleSize,
 			BundleHeight: txInfo.DesiredHeight,
@@ -210,9 +209,9 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 
 	// -------- BUNDLE EXISTENCE CHECKS ---------
 
-	var bundle *mempool.Bundle
+	var bundle *Bundle
 	// load existing bundle, or MAKE NEW if not
-	existingBundle, _ := sc.bundles.LoadOrStore(Key{txInfo.DesiredHeight, txInfo.BundleID}, &mempool.Bundle{
+	existingBundle, _ := sc.bundles.LoadOrStore(Key{txInfo.DesiredHeight, txInfo.BundleID}, &Bundle{
 		DesiredHeight: txInfo.DesiredHeight,
 		BundleID:      txInfo.BundleID,
 		CurrSize:      int64(0),
@@ -221,7 +220,7 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 		GasWanted:     int64(0),
 		OrderedTxsMap: &sync.Map{},
 	})
-	bundle = existingBundle.(*mempool.Bundle)
+	bundle = existingBundle.(*Bundle)
 
 	// -------- BUNDLE SIZE CHECKS ---------
 
@@ -235,7 +234,7 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 			"enforced size", bundle.EnforcedSize,
 			"tx", tx.Hash(),
 		)
-		return mempool.ErrTxMalformedForBundle{
+		return ErrTxMalformedForBundle{
 			BundleID:     txInfo.BundleID,
 			BundleSize:   txInfo.BundleSize,
 			BundleHeight: txInfo.DesiredHeight,
@@ -258,7 +257,7 @@ func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) erro
 				"enforced size", bundle.EnforcedSize,
 				"tx", tx.Hash(),
 			)
-			return false, mempool.ErrBundleFull{
+			return false, ErrBundleFull{
 				BundleID:     txInfo.BundleID,
 				BundleHeight: txInfo.BundleSize,
 			}
@@ -398,7 +397,7 @@ func (sc *CListPriorityTxSidecar) Update(
 
 	// remove from txs list and txmap
 	for e := sc.txs.Front(); e != nil; e = e.Next() {
-		scTx := e.Value.(*mempool.SidecarTx)
+		scTx := e.Value.(*SidecarTx)
 		if scTx.DesiredHeight <= height {
 			sc.logger.Debug(
 				"removed uncommited tx from sidecar",
@@ -415,7 +414,7 @@ func (sc *CListPriorityTxSidecar) Update(
 	// remove the bundles
 	sc.bundles.Range(func(key, _ interface{}) bool {
 		if bundle, ok := sc.bundles.Load(key); ok {
-			bundle := bundle.(*mempool.Bundle)
+			bundle := bundle.(*Bundle)
 			if bundle.DesiredHeight <= height {
 				sc.logger.Debug(
 					"removed bundle from sidecar",
@@ -489,7 +488,7 @@ func (sc *CListPriorityTxSidecar) HeightForFiringAuction() int64 {
 // Safe for concurrent use by multiple goroutines.
 func (sc *CListPriorityTxSidecar) GetEnforcedBundleSize(bundleID int64) int {
 	if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleID}); ok {
-		bundle := bundle.(*mempool.Bundle)
+		bundle := bundle.(*Bundle)
 		return int(bundle.EnforcedSize)
 	}
 	sc.logger.Info(
@@ -502,7 +501,7 @@ func (sc *CListPriorityTxSidecar) GetEnforcedBundleSize(bundleID int64) int {
 // Safe for concurrent use by multiple goroutines.
 func (sc *CListPriorityTxSidecar) GetCurrBundleSize(bundleID int64) int {
 	if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleID}); ok {
-		bundle := bundle.(*mempool.Bundle)
+		bundle := bundle.(*Bundle)
 		return int(bundle.CurrSize)
 	}
 	sc.logger.Info(
@@ -543,7 +542,7 @@ func (sc *CListPriorityTxSidecar) ReapMaxTxs() types.ReapedTxs {
 		"sidecarSize", sc.Size(),
 	)
 
-	memTxs := make([]*mempoolTx, 0, sc.txs.Len())
+	scTxs := make([]*SidecarTx, 0, sc.txs.Len())
 
 	if (sc.txs.Len() == 0) || (sc.NumBundles() == 0) {
 		return types.ReapedTxs{}
@@ -559,7 +558,7 @@ func (sc *CListPriorityTxSidecar) ReapMaxTxs() types.ReapedTxs {
 		bundleIDIter := int64(bundleIDIter)
 
 		if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleIDIter}); ok {
-			bundle := bundle.(*mempool.Bundle)
+			bundle := bundle.(*Bundle)
 			bundleOrderedTxsMap := bundle.OrderedTxsMap
 
 			// check to see if bundle is full, if not, just skip now
@@ -575,21 +574,14 @@ func (sc *CListPriorityTxSidecar) ReapMaxTxs() types.ReapedTxs {
 			}
 
 			// if full, iterate over bundle in order and add txs to temporary store, then add all if we have enough (i.e. matches enforcedBundleSize)
-			innerTxs := make([]*mempoolTx, 0, bundle.EnforcedSize)
+			innerTxs := make([]*SidecarTx, 0, bundle.EnforcedSize)
 			for bundleOrderIter := 0; bundleOrderIter < int(bundle.EnforcedSize); bundleOrderIter++ {
 				bundleOrderIter := int64(bundleOrderIter)
 
 				if scTx, ok := bundleOrderedTxsMap.Load(bundleOrderIter); ok {
 					// loading as sidecar tx, but casting to MempoolTx to return
-					scTx := scTx.(*mempool.SidecarTx)
-					memTx := &mempoolTx{
-						// CONTRACT: since the only height this could have been added into is desiredHeight = mem.height + 1,
-						// then this tx must have been validated against mem.height
-						height:    scTx.DesiredHeight - 1,
-						gasWanted: scTx.GasWanted,
-						tx:        scTx.Tx,
-					}
-					innerTxs = append(innerTxs, memTx)
+					scTx := scTx.(*SidecarTx)
+					innerTxs = append(innerTxs, scTx)
 				} else {
 					// can't find tx at this bundleOrder for this bundleID
 					sc.logger.Info(
@@ -604,7 +596,7 @@ func (sc *CListPriorityTxSidecar) ReapMaxTxs() types.ReapedTxs {
 			// check to see if we have the right number of transactions for the bundle, comparing to the enforced size
 			if bundle.EnforcedSize == int64(len(innerTxs)) {
 				// check to see if we've reaped the right number of txs expected for the bundle
-				memTxs = append(memTxs, innerTxs...)
+				scTxs = append(scTxs, innerTxs...)
 				completedBundles++
 				numTxsInBundles += len(innerTxs)
 
@@ -637,11 +629,11 @@ func (sc *CListPriorityTxSidecar) ReapMaxTxs() types.ReapedTxs {
 	sc.metrics.NumMevTxsLastBlock.Set(float64(numTxsInBundles))
 
 	// Gather info to return a ReapedTxs
-	txs := make([]types.Tx, 0, len(memTxs))
-	gasWanteds := make([]int64, 0, len(memTxs))
-	for _, memTx := range memTxs {
-		txs = append(txs, memTx.tx)
-		gasWanteds = append(gasWanteds, memTx.gasWanted)
+	txs := make([]types.Tx, 0, len(scTxs))
+	gasWanteds := make([]int64, 0, len(scTxs))
+	for _, scTx := range scTxs {
+		txs = append(txs, scTx.Tx)
+		gasWanteds = append(gasWanteds, scTx.GasWanted)
 	}
 	return types.ReapedTxs{
 		Txs:        txs,

--- a/mempool/clist_sidecar_test.go
+++ b/mempool/clist_sidecar_test.go
@@ -542,4 +542,3 @@ func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
 		t.Fatal("Expected to fire")
 	}
 }
-

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -45,7 +45,7 @@ type Mempool interface {
 	//
 	// If both maxes are negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*MempoolTx) types.Txs
+	ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs
 
 	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
 	// negative, there is no cap on the size of all returned transactions
@@ -112,7 +112,7 @@ type PriorityTxSidecar interface {
 	// ReapMaxTxs reaps up to max transactions from the mempool.
 	// If max is negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxTxs() []*MempoolTx
+	ReapMaxTxs() types.ReapedTxs
 
 	// Lock locks the mempool. The consensus must be able to hold lock to safely update.
 	Lock()
@@ -278,17 +278,6 @@ func (e ErrPreCheck) Error() string {
 // IsPreCheckError returns true if err is due to pre check failure.
 func IsPreCheckError(err error) bool {
 	return errors.As(err, &ErrPreCheck{})
-}
-
-// mempoolTx is a transaction that successfully ran
-type MempoolTx struct { //nolint:revive
-	Height    int64    // height that this tx had been validated in
-	GasWanted int64    // amount of gas this tx states it will require
-	Tx        types.Tx //
-
-	// ids of peers who've sent us this tx (as a map for quick lookups).
-	// senders: PeerID -> bool
-	Senders sync.Map
 }
 
 // MempoolTx is a transaction that successfully ran

--- a/mempool/mev_reap.go
+++ b/mempool/mev_reap.go
@@ -1,0 +1,64 @@
+package mempool
+
+import (
+	"fmt"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes, maxGas int64) types.Txs {
+	var (
+		totalGas    int64
+		runningSize int64
+	)
+
+	txs := make([]types.Tx, 0, (len(memplTxs.Txs) + len(sidecarTxs.Txs)))
+	sidecarTxsMap := make(map[types.TxKey]struct{})
+
+	for i, sidecarTx := range sidecarTxs.Txs {
+		fmt.Println("[mev-tendermint]: reaped sidecar mev transaction", sidecarTx.Hash())
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{sidecarTx})
+
+		// Check total size requirement
+		if maxBytes > -1 && runningSize+dataSize > maxBytes {
+			return txs
+		}
+		runningSize += dataSize
+
+		newTotalGas := totalGas + sidecarTxs.GasWanteds[i]
+		if maxGas > -1 && newTotalGas > maxGas {
+			return txs
+		}
+		totalGas = newTotalGas
+		txs = append(txs, sidecarTx)
+		sidecarTxsMap[sidecarTx.Key()] = struct{}{}
+	}
+
+	for i, memplTx := range memplTxs.Txs {
+		if _, ok := sidecarTxsMap[memplTx.Key()]; ok {
+			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
+			fmt.Println("[mev-tendermint]: skipped mempool tx, already found in sidecar", memplTx.Hash())
+			continue
+		}
+
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memplTx})
+
+		// Check total size requirement
+		if maxBytes > -1 && runningSize+dataSize > maxBytes {
+			return txs
+		}
+		runningSize += dataSize
+
+		// Check total gas requirement.
+		// If maxGas is negative, skip this check.
+		// Since newTotalGas < masGas, which
+		// must be non-negative, it follows that this won't overflow.
+		newTotalGas := totalGas + memplTxs.GasWanteds[i]
+		if maxGas > -1 && newTotalGas > maxGas {
+			return txs
+		}
+		totalGas = newTotalGas
+		txs = append(txs, memplTx)
+	}
+	return txs
+}

--- a/mempool/mev_reap.go
+++ b/mempool/mev_reap.go
@@ -16,7 +16,7 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 	sidecarTxsMap := make(map[types.TxKey]struct{})
 
 	for i, sidecarTx := range sidecarTxs.Txs {
-		fmt.Println("[mev-tendermint]: reaped sidecar mev transaction", sidecarTx.Hash())
+		fmt.Println("[mev-tendermint]: reaped sidecar mev transaction", getLastNumBytesFromTx(sidecarTx, 20))
 		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{sidecarTx})
 
 		// Check total size requirement
@@ -37,7 +37,7 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 	for i, memplTx := range memplTxs.Txs {
 		if _, ok := sidecarTxsMap[memplTx.Key()]; ok {
 			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
-			fmt.Println("[mev-tendermint]: skipped mempool tx, already found in sidecar", memplTx.Hash())
+			fmt.Println("[mev-tendermint]: skipped mempool tx, already found in sidecar", getLastNumBytesFromTx(memplTx, 20))
 			continue
 		}
 
@@ -61,4 +61,14 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 		txs = append(txs, memplTx)
 	}
 	return txs
+}
+
+func getLastNumBytesFromTx(tx types.Tx, numBytes int) string {
+	if len(tx) == 0 {
+		return ""
+	} else if len(tx) < 20 {
+		return tx.String()
+	} else {
+		return tx.String()[len(tx.String())-20:]
+	}
 }

--- a/mempool/mev_reap_test.go
+++ b/mempool/mev_reap_test.go
@@ -1,0 +1,34 @@
+package mempool
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/types"
+)
+
+func TestCombineSidecarAndMempoolTxs_SkipsSidecarTxsInMempoolReap(t *testing.T) {
+	tx := make([]byte, 20)
+	_, err := rand.Read(tx)
+	if err != nil {
+		t.Error(err)
+	}
+	// Put one tx in the mempool
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{tx},
+		GasWanteds: []int64{10},
+	}
+	// Put the same tx in sidecarTxs
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{tx},
+		GasWanteds: []int64{10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 50, 500)
+
+	// Assert that it only got reaped once
+	expectedTxs := types.Txs([]types.Tx{tx})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}

--- a/mempool/mev_reap_test.go
+++ b/mempool/mev_reap_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestCombineSidecarAndMempoolTxs_SkipsSidecarTxsInMempoolReap(t *testing.T) {
-	tx := make([]byte, 20)
-	_, err := rand.Read(tx)
-	if err != nil {
-		t.Error(err)
-	}
+	tx := makeTxWithNumBytes(t, 20)
 	// Put one tx in the mempool
 	memplTxs := types.ReapedTxs{
 		Txs:        []types.Tx{tx},
@@ -31,4 +27,141 @@ func TestCombineSidecarAndMempoolTxs_SkipsSidecarTxsInMempoolReap(t *testing.T) 
 	// Assert that it only got reaped once
 	expectedTxs := types.Txs([]types.Tx{tx})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarHassMaxBytes(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 50)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarHasMaxGas(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 20)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_MempoolHasMaxBytes(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	mplTx3 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2, mplTx3},
+		GasWanteds: []int64{10, 10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{},
+		GasWanteds: []int64{},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 40)
+
+	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_MempoolHasMaxGas(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	mplTx3 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2, mplTx3},
+		GasWanteds: []int64{10, 10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{},
+		GasWanteds: []int64{},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 20)
+
+	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_CombinedHasMaxBytes(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2},
+		GasWanteds: []int64{10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 60)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_CombinedHasMaxGas(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2},
+		GasWanteds: []int64{10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 30)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func makeTxWithNumBytes(t *testing.T, numBytes int) types.Tx {
+	tx := make([]byte, numBytes)
+	_, err := rand.Read(tx)
+	if err != nil {
+		t.Error(err)
+	}
+	return tx
 }

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -18,9 +18,9 @@ func (Mempool) Size() int { return 0 }
 func (Mempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempool.TxInfo) error {
 	return nil
 }
-func (Mempool) RemoveTxByKey(txKey types.TxKey) error                           { return nil }
-func (Mempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempool.MempoolTx) types.Txs { return types.Txs{} }
-func (Mempool) ReapMaxTxs(n int) types.Txs                                      { return types.Txs{} }
+func (Mempool) RemoveTxByKey(txKey types.TxKey) error         { return nil }
+func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs { return types.ReapedTxs{} }
+func (Mempool) ReapMaxTxs(n int) types.Txs                    { return types.Txs{} }
 func (Mempool) Update(
 	_ int64,
 	_ types.Txs,
@@ -48,7 +48,7 @@ type PriorityTxSidecar struct{}
 var _ mempool.PriorityTxSidecar = PriorityTxSidecar{}
 
 func (PriorityTxSidecar) AddTx(_ types.Tx, _ mempool.TxInfo) error { return nil }
-func (PriorityTxSidecar) ReapMaxTxs() []*mempool.MempoolTx         { return []*mempool.MempoolTx{} }
+func (PriorityTxSidecar) ReapMaxTxs() types.ReapedTxs              { return types.ReapedTxs{} }
 
 func (PriorityTxSidecar) Lock()   {}
 func (PriorityTxSidecar) Unlock() {}

--- a/mempool/v0/bench_test.go
+++ b/mempool/v0/bench_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkReap(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000
@@ -28,14 +28,14 @@ func BenchmarkReap(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mp.ReapMaxBytesMaxGas(100000000, 10000000, nil)
+		mp.ReapMaxBytesMaxGas(100000000, 10000000)
 	}
 }
 
 func BenchmarkCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000
@@ -57,7 +57,7 @@ func BenchmarkCheckTx(b *testing.B) {
 func BenchmarkParallelCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000000
@@ -82,7 +82,7 @@ func BenchmarkParallelCheckTx(b *testing.B) {
 func BenchmarkCheckDuplicateTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000

--- a/mempool/v0/cache_test.go
+++ b/mempool/v0/cache_test.go
@@ -16,7 +16,7 @@ import (
 func TestCacheAfterUpdate(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// reAddIndices & txsInCache can have elements > numTxsToCreate

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -242,8 +242,8 @@ func (mem *CListMempool) CheckTx(
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(tx.Key()); ok {
-			memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
-			memTx.Senders.LoadOrStore(txInfo.SenderID, true)
+			memTx := e.(*clist.CElement).Value.(*mempoolTx)
+			memTx.senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
@@ -313,11 +313,11 @@ func (mem *CListMempool) reqResCb(
 
 // Called from:
 //   - resCbFirstTime (lock not held) if tx is valid
-func (mem *CListMempool) addTx(memTx *mempool.MempoolTx) {
+func (mem *CListMempool) addTx(memTx *mempoolTx) {
 	e := mem.txs.PushBack(memTx)
-	mem.txsMap.Store(memTx.Tx.Key(), e)
-	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.Tx)))
-	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.Tx)))
+	mem.txsMap.Store(memTx.tx.Key(), e)
+	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.tx)))
+	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.tx)))
 }
 
 // Called from:
@@ -337,9 +337,9 @@ func (mem *CListMempool) removeTx(tx types.Tx, elem *clist.CElement, removeFromC
 // RemoveTxByKey removes a transaction from the mempool by its TxKey index.
 func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 	if e, ok := mem.txsMap.Load(txKey); ok {
-		memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
+		memTx := e.(*clist.CElement).Value.(*mempoolTx)
 		if memTx != nil {
-			mem.removeTx(memTx.Tx, e.(*clist.CElement), false)
+			mem.removeTx(memTx.tx, e.(*clist.CElement), false)
 			return nil
 		}
 		return errors.New("transaction not found")
@@ -391,18 +391,18 @@ func (mem *CListMempool) resCbFirstTime(
 				return
 			}
 
-			memTx := &mempool.MempoolTx{
-				Height:    mem.height,
-				GasWanted: r.CheckTx.GasWanted,
-				Tx:        tx,
+			memTx := &mempoolTx{
+				height:    mem.height,
+				gasWanted: r.CheckTx.GasWanted,
+				tx:        tx,
 			}
-			memTx.Senders.Store(peerID, true)
+			memTx.senders.Store(peerID, true)
 			mem.addTx(memTx)
 			mem.logger.Debug(
 				"added good transaction",
 				"tx", types.Tx(tx).Hash(),
 				"res", r,
-				"height", memTx.Height,
+				"height", memTx.height,
 				"total", mem.Size(),
 			)
 			mem.notifyTxsAvailable()
@@ -436,12 +436,12 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 	switch r := res.Value.(type) {
 	case *abci.Response_CheckTx:
 		tx := req.GetCheckTx().Tx
-		memTx := mem.recheckCursor.Value.(*mempool.MempoolTx)
+		memTx := mem.recheckCursor.Value.(*mempoolTx)
 
 		// Search through the remaining list of tx to recheck for a transaction that matches
 		// the one we received from the ABCI application.
 		for {
-			if bytes.Equal(tx, memTx.Tx) {
+			if bytes.Equal(tx, memTx.tx) {
 				// We've found a tx in the recheck list that matches the tx that we
 				// received from the ABCI application.
 				// Break, and use this transaction for further checks.
@@ -451,7 +451,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			mem.logger.Error(
 				"re-CheckTx transaction mismatch",
 				"got", types.Tx(tx),
-				"expected", memTx.Tx,
+				"expected", memTx.tx,
 			)
 
 			if mem.recheckCursor == mem.recheckEnd {
@@ -463,7 +463,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			}
 
 			mem.recheckCursor = mem.recheckCursor.Next()
-			memTx = mem.recheckCursor.Value.(*mempool.MempoolTx)
+			memTx = mem.recheckCursor.Value.(*mempoolTx)
 		}
 
 		var postCheckErr error
@@ -518,7 +518,7 @@ func (mem *CListMempool) notifyTxsAvailable() {
 }
 
 // Safe for concurrent use by multiple goroutines.
-func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*mempool.MempoolTx) types.Txs {
+func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs {
 	mem.updateMtx.RLock()
 	defer mem.updateMtx.RUnlock()
 
@@ -527,51 +527,25 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 		runningSize int64
 	)
 
-	txs := make([]types.Tx, 0, (mem.txs.Len() + len(sidecarTxs)))
-	var sidecarTxsMap sync.Map
-
-	for _, scMemTx := range sidecarTxs {
-		mem.logger.Debug(
-			"reaped sidecar mev transaction",
-			"tx", scMemTx.Tx.Hash(),
-			"height", scMemTx.Height,
-		)
-		dataSize := types.ComputeProtoSizeForTxs(append(txs, scMemTx.Tx))
-
-		// Check total size requirement
-		if maxBytes > -1 && dataSize > maxBytes {
-			return txs
-		}
-
-		newTotalGas := totalGas + scMemTx.GasWanted
-		if maxGas > -1 && newTotalGas > maxGas {
-			return txs
-		}
-		totalGas = newTotalGas
-		txs = append(txs, scMemTx.Tx)
-		sidecarTxsMap.Store(scMemTx.Tx.Key(), true)
-	}
-
+	// TODO: we will get a performance boost if we have a good estimate of avg
+	// size per tx, and set the initial capacity based off of that.
+	// txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max/mem.avgTxSize))
+	txs := make([]types.Tx, 0, mem.txs.Len())
+	gasWanteds := make([]int64, 0, mem.txs.Len())
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
+		memTx := e.Value.(*mempoolTx)
 
-		if _, ok := sidecarTxsMap.Load(memTx.Tx.Key()); ok {
-			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
-			mem.logger.Debug(
-				"skipped mempool tx, already found in sidecar",
-				"tx", memTx.Tx.Hash(),
-				"height", memTx.Height,
-			)
-			continue
-		}
+		txs = append(txs, memTx.tx)
+		gasWanteds = append(gasWanteds, memTx.gasWanted)
 
-		txs = append(txs, memTx.Tx)
-
-		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.Tx})
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.tx})
 
 		// Check total size requirement
 		if maxBytes > -1 && runningSize+dataSize > maxBytes {
-			return txs[:len(txs)-1]
+			return types.ReapedTxs{
+				Txs:        txs[:len(txs)-1],
+				GasWanteds: gasWanteds[:len(txs)-1],
+			}
 		}
 
 		runningSize += dataSize
@@ -580,13 +554,19 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 		// If maxGas is negative, skip this check.
 		// Since newTotalGas < masGas, which
 		// must be non-negative, it follows that this won't overflow.
-		newTotalGas := totalGas + memTx.GasWanted
+		newTotalGas := totalGas + memTx.gasWanted
 		if maxGas > -1 && newTotalGas > maxGas {
-			return txs[:len(txs)-1]
+			return types.ReapedTxs{
+				Txs:        txs[:len(txs)-1],
+				GasWanteds: gasWanteds[:len(txs)-1],
+			}
 		}
 		totalGas = newTotalGas
 	}
-	return txs
+	return types.ReapedTxs{
+		Txs:        txs,
+		GasWanteds: gasWanteds,
+	}
 }
 
 // Safe for concurrent use by multiple goroutines.
@@ -600,8 +580,8 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 
 	txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max))
 	for e := mem.txs.Front(); e != nil && len(txs) <= max; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
-		txs = append(txs, memTx.Tx)
+		memTx := e.Value.(*mempoolTx)
+		txs = append(txs, memTx.tx)
 	}
 	return txs
 }
@@ -680,9 +660,9 @@ func (mem *CListMempool) recheckTxs() {
 	// Push txs to proxyAppConn
 	// NOTE: globalCb may be called concurrently.
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
+		memTx := e.Value.(*mempoolTx)
 		mem.proxyAppConn.CheckTxAsync(abci.RequestCheckTx{
-			Tx:   memTx.Tx,
+			Tx:   memTx.tx,
 			Type: abci.CheckTxType_Recheck,
 		})
 	}
@@ -691,3 +671,19 @@ func (mem *CListMempool) recheckTxs() {
 }
 
 //--------------------------------------------------------------------------------
+
+// mempoolTx is a transaction that successfully ran
+type mempoolTx struct {
+	height    int64    // height that this tx had been validated in
+	gasWanted int64    // amount of gas this tx states it will require
+	tx        types.Tx //
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	senders sync.Map
+}
+
+// Height returns the height for this transaction
+func (memTx *mempoolTx) Height() int64 {
+	return atomic.LoadInt64(&memTx.height)
+}

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -34,17 +33,6 @@ import (
 // test.
 type cleanupFunc func()
 
-type testBundleInfo struct {
-	BundleSize    int64
-	DesiredHeight int64
-	BundleID      int64
-	PeerID        uint16
-}
-
-var (
-	ZeroedTxInfoForSidecar = mempool.TxInfo{DesiredHeight: 1, BundleID: 0, BundleOrder: 0, BundleSize: 1}
-)
-
 func newMempoolWithAppMock(cc proxy.ClientCreator, client abciclient.Client) (*CListMempool, cleanupFunc, error) {
 	conf := config.ResetTestRoot("mempool_test")
 
@@ -68,14 +56,14 @@ func newMempoolWithAppAndConfigMock(cc proxy.ClientCreator,
 	return mp, func() { os.RemoveAll(cfg.RootDir) }
 }
 
-func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, *CListPriorityTxSidecar, cleanupFunc) {
+func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, cleanupFunc) {
 	conf := config.ResetTestRoot("mempool_test")
 
-	mp, sc, cu := newMempoolWithAppAndConfig(cc, conf)
-	return mp, sc, cu
+	mp, cu := newMempoolWithAppAndConfig(cc, conf)
+	return mp, cu
 }
 
-func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CListMempool, *CListPriorityTxSidecar, cleanupFunc) {
+func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CListMempool, cleanupFunc) {
 	appConnMem, _ := cc.NewABCIClient()
 	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	err := appConnMem.Start()
@@ -85,9 +73,8 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CL
 
 	mp := NewCListMempool(cfg.Mempool, appConnMem, 0)
 	mp.SetLogger(log.TestingLogger())
-	sidecar := NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 
-	return mp, sidecar, func() { os.RemoveAll(cfg.RootDir) }
+	return mp, func() { os.RemoveAll(cfg.RootDir) }
 }
 
 func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
@@ -108,7 +95,7 @@ func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
 	}
 }
 
-func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sidecar mempool.PriorityTxSidecar, addToSidecar bool) types.Txs {
+func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16) types.Txs {
 	txs := make(types.Txs, count)
 	txInfo := mempool.TxInfo{SenderID: peerID}
 	for i := 0; i < count; i++ {
@@ -127,11 +114,6 @@ func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sideca
 			}
 			t.Fatalf("CheckTx failed: %v while checking #%d tx", err, i)
 		}
-		if addToSidecar {
-			if err := sidecar.AddTx(txBytes, txInfo); err != nil {
-				t.Error(err)
-			}
-		}
 	}
 	return txs
 }
@@ -139,17 +121,17 @@ func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sideca
 func TestReapMaxBytesMaxGas(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// Ensure gas calculation behaves as expected
-	checkTxs(t, mp, 1, mempool.UnknownPeerID, nil, false)
-	tx0 := mp.TxsFront().Value.(*mempool.MempoolTx)
+	checkTxs(t, mp, 1, mempool.UnknownPeerID)
+	tx0 := mp.TxsFront().Value.(*mempoolTx)
 	// assert that kv store has gas wanted = 1.
-	require.Equal(t, app.CheckTx(abci.RequestCheckTx{Tx: tx0.Tx}).GasWanted, int64(1), "KVStore had a gas value neq to 1")
-	require.Equal(t, tx0.GasWanted, int64(1), "transactions gas was set incorrectly")
+	require.Equal(t, app.CheckTx(abci.RequestCheckTx{Tx: tx0.tx}).GasWanted, int64(1), "KVStore had a gas value neq to 1")
+	require.Equal(t, tx0.gasWanted, int64(1), "transactions gas was set incorrectly")
 	// ensure each tx is 20 bytes long
-	require.Equal(t, len(tx0.Tx), 20, "Tx is longer than 20 bytes")
+	require.Equal(t, len(tx0.tx), 20, "Tx is longer than 20 bytes")
 	mp.Flush()
 
 	// each table driven test creates numTxsToCreate txs with checkTx, and at the end clears all remaining txs.
@@ -177,67 +159,18 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 		{20, 20000, 30, 20},
 	}
 	for tcIndex, tt := range tests {
-		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID, nil, false)
-		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas, nil)
-		assert.Equal(t, tt.expectedNumTxs, len(got), "Got %d txs, expected %d, tc #%d",
-			len(got), tt.expectedNumTxs, tcIndex)
+		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID)
+		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas)
+		assert.Equal(t, tt.expectedNumTxs, len(got.Txs), "Got %d txs, expected %d, tc #%d",
+			len(got.Txs), tt.expectedNumTxs, tcIndex)
 		mp.Flush()
 	}
-}
-
-func TestReapMaxBytesMaxGas_ReapsSidecar(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// Make sidecar txes consisting of one tx
-	tx := tmrand.Bytes(20)
-	expectedTxs := make(types.Txs, 1)
-	expectedTxs[0] = tx
-	sidecarTxs := []*mempool.MempoolTx{
-		{
-			Height:    5,
-			GasWanted: 100,
-			Tx:        tx,
-		},
-	}
-
-	// Pass sidecar txes to reap
-	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
-
-	// Assert that it got reaped
-	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
-}
-
-func TestReapMaxBytesMaxGas_SkipsSidecarTxsInMempoolReap(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// Put one tx in the mempool
-	expectedTxs := checkTxs(t, mp, 1, mempool.UnknownPeerID, nil, false)
-	// Put the same tx in sidecarTxs
-	sidecarTxs := []*mempool.MempoolTx{
-		{
-			Height:    5,
-			GasWanted: 100,
-			Tx:        expectedTxs[0],
-		},
-	}
-
-	// Reap
-	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
-
-	// Assert that it only got reaped once
-	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
 }
 
 func TestMempoolFilters(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 	emptyTxArr := []types.Tx{[]byte{}}
 
@@ -267,7 +200,7 @@ func TestMempoolFilters(t *testing.T) {
 	for tcIndex, tt := range tests {
 		err := mp.Update(1, emptyTxArr, abciResponses(len(emptyTxArr), abci.CodeTypeOK), tt.preFilter, tt.postFilter)
 		require.NoError(t, err)
-		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID, nil, false)
+		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID)
 		require.Equal(t, tt.expectedNumTxs, mp.Size(), "mempool had the incorrect size, on test case %d", tcIndex)
 		mp.Flush()
 	}
@@ -276,7 +209,7 @@ func TestMempoolFilters(t *testing.T) {
 func TestMempoolUpdate(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// 1. Adds valid txs to the cache
@@ -366,7 +299,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 	cc := proxy.NewLocalClientCreator(app)
 	wcfg := config.DefaultConfig()
 	wcfg.Mempool.KeepInvalidTxsInCache = true
-	mp, _, cleanup := newMempoolWithAppAndConfig(cc, wcfg)
+	mp, cleanup := newMempoolWithAppAndConfig(cc, wcfg)
 	defer cleanup()
 
 	// 1. An invalid transaction must remain in the cache after Update
@@ -416,7 +349,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 func TestTxsAvailable(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 	mp.EnableTxsAvailable()
 
@@ -426,7 +359,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch of txs, it should only fire once
-	txs := checkTxs(t, mp, 100, mempool.UnknownPeerID, nil, false)
+	txs := checkTxs(t, mp, 100, mempool.UnknownPeerID)
 	ensureFire(t, mp.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
@@ -441,7 +374,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch more txs. we already fired for this height so it shouldnt fire again
-	moreTxs := checkTxs(t, mp, 50, mempool.UnknownPeerID, nil, false)
+	moreTxs := checkTxs(t, mp, 50, mempool.UnknownPeerID)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// now call update with all the txs. it should not fire as there are no txs left
@@ -452,7 +385,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch more txs, it should only fire once
-	checkTxs(t, mp, 100, mempool.UnknownPeerID, nil, false)
+	checkTxs(t, mp, 100, mempool.UnknownPeerID)
 	ensureFire(t, mp.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 }
@@ -461,7 +394,7 @@ func TestSerialReap(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
 
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	appConnCon, _ := cc.NewABCIClient()
@@ -493,8 +426,8 @@ func TestSerialReap(t *testing.T) {
 	}
 
 	reapCheck := func(exp int) {
-		txs := mp.ReapMaxBytesMaxGas(-1, -1, nil)
-		require.Equal(t, len(txs), exp, fmt.Sprintf("Expected to reap %v txs but got %v", exp, len(txs)))
+		txs := mp.ReapMaxBytesMaxGas(-1, -1)
+		require.Equal(t, len(txs.Txs), exp, fmt.Sprintf("Expected to reap %v txs but got %v", exp, len(txs.Txs)))
 	}
 
 	updateRange := func(start, end int) {
@@ -567,43 +500,11 @@ func TestSerialReap(t *testing.T) {
 	reapCheck(600)
 }
 
-// multiple go routines constantly try to insert bundles
-// as they get reaped
-func TestMempoolConcurrency(t *testing.T) {
-
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	var wg sync.WaitGroup
-
-	numProcesses := 15
-	numBundlesToAddPerProcess := 5
-	numTxPerBundle := 10
-	wg.Add(numProcesses)
-
-	for i := 0; i < numProcesses; i++ {
-
-		go func() {
-			defer wg.Done()
-			addNumBundlesToSidecar(t, sidecar, numBundlesToAddPerProcess, int64(numTxPerBundle), mempool.UnknownPeerID)
-		}()
-
-	}
-
-	wg.Wait()
-
-	txs := sidecar.ReapMaxTxs()
-	assert.Equal(t, (numBundlesToAddPerProcess * numTxPerBundle), len(txs), "Got %d txs, expected %d",
-		len(txs), (numBundlesToAddPerProcess * numTxPerBundle))
-}
-
 func TestMempool_CheckTxChecksTxSize(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
 
-	mempl, _, cleanup := newMempoolWithApp(cc)
+	mempl, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	maxTxSize := mempl.config.MaxTxBytes
@@ -652,7 +553,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	cfg := config.ResetTestRoot("mempool_test")
 
 	cfg.Mempool.MaxTxsBytes = 10
-	mp, _, cleanup := newMempoolWithAppAndConfig(cc, cfg)
+	mp, cleanup := newMempoolWithAppAndConfig(cc, cfg)
 	defer cleanup()
 
 	// 1. zero by default
@@ -693,7 +594,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	app2 := kvstore.NewApplication()
 	cc = proxy.NewLocalClientCreator(app2)
 
-	mp, _, cleanup = newMempoolWithApp(cc)
+	mp, cleanup = newMempoolWithApp(cc)
 	defer cleanup()
 
 	txBytes := make([]byte, 8)
@@ -753,7 +654,7 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 
 	cfg := config.ResetTestRoot("mempool_test")
 
-	mp, _, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
+	mp, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
 	defer cleanup()
 
 	// generate small number of txs

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -160,9 +160,9 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 	}
 	for tcIndex, tt := range tests {
 		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID)
-		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas)
-		assert.Equal(t, tt.expectedNumTxs, len(got.Txs), "Got %d txs, expected %d, tc #%d",
-			len(got.Txs), tt.expectedNumTxs, tcIndex)
+		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas).Txs
+		assert.Equal(t, tt.expectedNumTxs, len(got), "Got %d txs, expected %d, tc #%d",
+			len(got), tt.expectedNumTxs, tcIndex)
 		mp.Flush()
 	}
 }
@@ -426,8 +426,8 @@ func TestSerialReap(t *testing.T) {
 	}
 
 	reapCheck := func(exp int) {
-		txs := mp.ReapMaxBytesMaxGas(-1, -1)
-		require.Equal(t, len(txs.Txs), exp, fmt.Sprintf("Expected to reap %v txs but got %v", exp, len(txs.Txs)))
+		txs := mp.ReapMaxBytesMaxGas(-1, -1).Txs
+		require.Equal(t, len(txs), exp, fmt.Sprintf("Expected to reap %v txs but got %v", exp, len(txs)))
 	}
 
 	updateRange := func(start, end int) {

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -22,7 +22,7 @@ type Reactor struct {
 	p2p.BaseReactor
 	config  *cfg.MempoolConfig
 	mempool *CListMempool
-	sidecar *CListPriorityTxSidecar
+	sidecar *mempool.CListPriorityTxSidecar
 	ids     *mempoolIDs
 }
 
@@ -90,7 +90,7 @@ func newMempoolIDs() *mempoolIDs {
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
-func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool, sidecar *CListPriorityTxSidecar) *Reactor {
+func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool, sidecar *mempool.CListPriorityTxSidecar) *Reactor {
 	memR := &Reactor{
 		config:  config,
 		mempool: mempool,

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -287,7 +287,8 @@ func (memR *Reactor) broadcastSidecarTxRoutine(peer p2p.Peer) {
 				}
 				bz, err := msg.Marshal()
 				if err != nil {
-					panic(err)
+					memR.Logger.Info("not sending a sidecarTx for peer", peerID, "failed to marshal", msg)
+					continue
 				}
 				success := peer.Send(mempool.SidecarChannel, bz)
 				if !success {

--- a/mempool/v0/reactor_test.go
+++ b/mempool/v0/reactor_test.go
@@ -1,8 +1,10 @@
 package v0
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -382,7 +384,7 @@ func makeAndConnectReactorsEvensSidecar(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
-		sidecar := NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
@@ -405,7 +407,7 @@ func makeAndConnectReactors(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
-		sidecar := NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
@@ -507,4 +509,48 @@ func TestMempoolVectors(t *testing.T) {
 
 		require.Equal(t, tc.expBytes, hex.EncodeToString(bz), tc.testName)
 	}
+}
+
+// Sidecar testing utils
+
+type testBundleInfo struct {
+	BundleSize    int64
+	DesiredHeight int64
+	BundleID      int64
+	PeerID        uint16
+}
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
 }

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -320,10 +320,11 @@ func (txmp *TxMempool) allEntriesSorted() []*WrappedTx {
 //
 // If the mempool is empty or has no transactions fitting within the given
 // constraints, the result will also be empty.
-func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, nilTxs []*mempool.MempoolTx) types.Txs {
+func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs {
 	var totalGas, totalBytes int64
 
-	var keep []types.Tx //nolint:prealloc
+	var keep []types.Tx    //nolint:prealloc
+	var gasWanteds []int64 //nolint:prealloc
 	for _, w := range txmp.allEntriesSorted() {
 		// N.B. When computing byte size, we need to include the overhead for
 		// encoding as protobuf to send to the application.
@@ -333,8 +334,12 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, nilTxs []*memp
 			break
 		}
 		keep = append(keep, w.tx)
+		gasWanteds = append(gasWanteds, w.gasWanted)
 	}
-	return keep
+	return types.ReapedTxs{
+		Txs:        keep,
+		GasWanteds: gasWanteds,
+	}
 }
 
 // TxsWaitChan returns a channel that is closed when there is at least one

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -330,14 +330,14 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	}
 
 	// reap by gas capacity only
-	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, nil)
+	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 50)
 
 	// reap by transaction bytes only
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1, nil)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -345,7 +345,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 
 	// Reap by both transaction bytes and gas, where the size yields 31 reaped
 	// transactions and the gas limit reaps 25 transactions.
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30, nil)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmsync "github.com/tendermint/tendermint/libs/sync"
 	"github.com/tendermint/tendermint/mempool"
-	mempoolv0 "github.com/tendermint/tendermint/mempool/v0"
 	"github.com/tendermint/tendermint/p2p"
 	protomem "github.com/tendermint/tendermint/proto/tendermint/mempool"
 	"github.com/tendermint/tendermint/types"
@@ -23,7 +22,7 @@ type Reactor struct {
 	p2p.BaseReactor
 	config  *cfg.MempoolConfig
 	mempool *TxMempool
-	sidecar *mempoolv0.CListPriorityTxSidecar
+	sidecar *mempool.CListPriorityTxSidecar
 	ids     *mempoolIDs
 }
 
@@ -91,7 +90,7 @@ func newMempoolIDs() *mempoolIDs {
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
-func NewReactor(config *cfg.MempoolConfig, mempool *TxMempool, sidecar *mempoolv0.CListPriorityTxSidecar) *Reactor {
+func NewReactor(config *cfg.MempoolConfig, mempool *TxMempool, sidecar *mempool.CListPriorityTxSidecar) *Reactor {
 	memR := &Reactor{
 		config:  config,
 		mempool: mempool,

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmsync "github.com/tendermint/tendermint/libs/sync"
 	"github.com/tendermint/tendermint/mempool"
+	mempoolv0 "github.com/tendermint/tendermint/mempool/v0"
 	"github.com/tendermint/tendermint/p2p"
 	protomem "github.com/tendermint/tendermint/proto/tendermint/mempool"
 	"github.com/tendermint/tendermint/types"
@@ -22,6 +23,7 @@ type Reactor struct {
 	p2p.BaseReactor
 	config  *cfg.MempoolConfig
 	mempool *TxMempool
+	sidecar *mempoolv0.CListPriorityTxSidecar
 	ids     *mempoolIDs
 }
 
@@ -89,10 +91,11 @@ func newMempoolIDs() *mempoolIDs {
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
-func NewReactor(config *cfg.MempoolConfig, mempool *TxMempool) *Reactor {
+func NewReactor(config *cfg.MempoolConfig, mempool *TxMempool, sidecar *mempoolv0.CListPriorityTxSidecar) *Reactor {
 	memR := &Reactor{
 		config:  config,
 		mempool: mempool,
+		sidecar: sidecar,
 		ids:     newMempoolIDs(),
 	}
 	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
@@ -134,6 +137,11 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 			Priority:            5,
 			RecvMessageCapacity: batchMsg.Size(),
 		},
+		{
+			ID:                  mempool.SidecarChannel,
+			Priority:            5,
+			RecvMessageCapacity: batchMsg.Size(),
+		},
 	}
 }
 
@@ -142,6 +150,9 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 func (memR *Reactor) AddPeer(peer p2p.Peer) {
 	if memR.config.Broadcast {
 		go memR.broadcastTxRoutine(peer)
+		if peer.IsSidecarPeer() {
+			go memR.broadcastSidecarTxRoutine(peer)
+		}
 	}
 }
 
@@ -155,31 +166,149 @@ func (memR *Reactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 // It adds any received transactions to the mempool.
 func (memR *Reactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 	msg, err := memR.decodeMsg(msgBytes)
-	if err != nil {
-		memR.Logger.Error("Error decoding message", "src", src, "chId", chID, "err", err)
-		memR.Switch.StopPeerForError(src, err)
-		return
-	}
-	memR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)
+	isSidecarPeer := src.IsSidecarPeer()
+	if chID == mempool.MempoolChannel {
+		if err != nil {
+			memR.Logger.Error("Error decoding message", "src", src, "chId", chID, "err", err)
+			memR.Switch.StopPeerForError(src, err)
+			return
+		}
+		memR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)
 
-	txInfo := mempool.TxInfo{SenderID: memR.ids.GetForPeer(src)}
-	if src != nil {
-		txInfo.SenderP2PID = src.ID()
-	}
-	for _, tx := range msg.Txs {
-		err = memR.mempool.CheckTx(tx, nil, txInfo)
-		if err == mempool.ErrTxInCache {
-			memR.Logger.Debug("Tx already exists in cache", "tx", tx.String())
-		} else if err != nil {
-			memR.Logger.Info("Could not check tx", "tx", tx.String(), "err", err)
+		txInfo := mempool.TxInfo{SenderID: memR.ids.GetForPeer(src)}
+		if src != nil {
+			txInfo.SenderP2PID = src.ID()
+		}
+		for _, tx := range msg.Txs {
+			err = memR.mempool.CheckTx(tx, nil, txInfo)
+			if err == mempool.ErrTxInCache {
+				memR.Logger.Debug("Tx already exists in cache", "tx", tx.String())
+			} else if err != nil {
+				memR.Logger.Info("Could not check tx", "tx", tx.String(), "err", err)
+			}
+		}
+	} else if chID == mempool.SidecarChannel && isSidecarPeer {
+		msg, err := memR.decodeBundleMsg(msgBytes)
+		if err != nil {
+			memR.Logger.Error(
+				"Error decoding sidecar message",
+				"src", src,
+				"chId", chID,
+				"err", err,
+			)
+			memR.Switch.StopPeerForError(src, err)
+			return
+		}
+		txInfo := mempool.TxInfo{
+			SenderID:      memR.ids.GetForPeer(src),
+			DesiredHeight: msg.DesiredHeight,
+			BundleID:      msg.BundleID,
+			BundleOrder:   msg.BundleOrder,
+			BundleSize:    msg.BundleSize,
+		}
+		if src != nil {
+			txInfo.SenderP2PID = src.ID()
+		}
+		for _, tx := range msg.Txs {
+			memR.Logger.Debug(
+				"received sidecar tx",
+				"tx", tx.Hash(),
+				"desired height", msg.DesiredHeight,
+				"bundle ID", msg.BundleID,
+				"bundle order", msg.BundleOrder,
+				"bundle size", msg.BundleSize,
+			)
+
+			err = memR.sidecar.AddTx(tx, txInfo)
+			if err == mempool.ErrTxInCache {
+				memR.Logger.Debug("sidecartx already exists in cache!", "tx", tx.Hash())
+			} else if err != nil {
+				memR.Logger.Info("could not add SidecarTx", "tx", tx.String(), "err", err)
+			}
 		}
 	}
+
 	// broadcasting happens from go routines per peer
 }
 
 // PeerState describes the state of a peer.
 type PeerState interface {
 	GetHeight() int64
+}
+
+func (memR *Reactor) broadcastSidecarTxRoutine(peer p2p.Peer) {
+	peerID := memR.ids.GetForPeer(peer)
+	isSidecarPeer := peer.IsSidecarPeer()
+	var next *clist.CElement
+
+	for {
+		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
+		if !memR.IsRunning() || !peer.IsRunning() {
+			return
+		}
+		// This happens because the CElement we were looking at got garbage
+		// collected (removed). That is, .NextWait() returned nil. Go ahead and
+		// start from the beginning.
+		if next == nil {
+			select {
+			case <-memR.sidecar.TxsWaitChan(): // Wait until a tx is available in sidecar
+				// if a tx is available on sidecar, if fire is set too, then fire
+				if next = memR.sidecar.TxsFront(); next == nil {
+					continue
+				}
+			case <-peer.Quit():
+				return
+			case <-memR.Quit():
+				return
+			}
+		}
+
+		if scTx, okConv := next.Value.(*mempool.SidecarTx); okConv && isSidecarPeer {
+			memR.Logger.Debug(
+				"broadcasting a sidecarTx to peer",
+				"peer", peerID,
+				"tx", scTx.Tx.Hash(),
+			)
+			if _, ok := scTx.Senders.Load(peerID); !ok {
+				msg := protomem.MEVMessage{
+					Sum: &protomem.MEVMessage_Txs{
+						Txs: &protomem.Txs{Txs: [][]byte{scTx.Tx}},
+					},
+					DesiredHeight: scTx.DesiredHeight,
+					BundleId:      scTx.BundleID,
+					BundleOrder:   scTx.BundleOrder,
+					BundleSize:    scTx.BundleSize,
+				}
+				bz, err := msg.Marshal()
+				if err != nil {
+					panic(err)
+				}
+				success := peer.Send(mempool.SidecarChannel, bz)
+				if !success {
+					time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
+					continue
+				}
+			} else {
+				memR.Logger.Info(
+					"broadcasting sidecarTx to peer failed",
+					"peer", peerID,
+					"was considered sidecarPeer", isSidecarPeer,
+					"was converted to sidecarTx", okConv,
+					"tx", scTx.Tx.Hash(),
+				)
+			}
+		}
+
+		select {
+		case <-next.NextWaitChan():
+			// see the start of the for loop for nil check
+			next = next.Next()
+		case <-peer.Quit():
+			return
+		case <-memR.Quit():
+			return
+		}
+	}
 }
 
 // Send new mempool txs to peer.
@@ -268,6 +397,39 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 //-----------------------------------------------------------------------------
 // Messages
 
+func (memR *Reactor) decodeBundleMsg(bz []byte) (MEVTxsMessage, error) {
+	msg := protomem.MEVMessage{}
+	err := msg.Unmarshal(bz)
+	if err != nil {
+		return MEVTxsMessage{}, err
+	}
+
+	var message MEVTxsMessage
+
+	if i, ok := msg.Sum.(*protomem.MEVMessage_Txs); ok {
+		txs := i.Txs.GetTxs()
+
+		if len(txs) == 0 {
+			return message, errors.New("empty TxsMessage")
+		}
+
+		decoded := make([]types.Tx, len(txs))
+		for j, tx := range txs {
+			decoded[j] = types.Tx(tx)
+		}
+
+		message = MEVTxsMessage{
+			Txs:           decoded,
+			DesiredHeight: msg.GetDesiredHeight(),
+			BundleID:      msg.GetBundleId(),
+			BundleOrder:   msg.GetBundleOrder(),
+			BundleSize:    msg.GetBundleSize(),
+		}
+		return message, nil
+	}
+	return message, fmt.Errorf("msg type: %T is not supported", msg)
+}
+
 func (memR *Reactor) decodeMsg(bz []byte) (TxsMessage, error) {
 	msg := protomem.Message{}
 	err := msg.Unmarshal(bz)
@@ -298,6 +460,14 @@ func (memR *Reactor) decodeMsg(bz []byte) (TxsMessage, error) {
 }
 
 //-------------------------------------
+
+type MEVTxsMessage struct {
+	Txs           []types.Tx
+	DesiredHeight int64
+	BundleID      int64
+	BundleOrder   int64
+	BundleSize    int64
+}
 
 // TxsMessage is a Message containing transactions.
 type TxsMessage struct {

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -281,7 +281,8 @@ func (memR *Reactor) broadcastSidecarTxRoutine(peer p2p.Peer) {
 				}
 				bz, err := msg.Marshal()
 				if err != nil {
-					panic(err)
+					memR.Logger.Info("not sending a sidecarTx for peer", peerID, "failed to marshal", msg)
+					continue
 				}
 				success := peer.Send(mempool.SidecarChannel, bz)
 				if !success {

--- a/mempool/v1/reactor_test.go
+++ b/mempool/v1/reactor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mempool"
+	mempoolv0 "github.com/tendermint/tendermint/mempool/v0"
 	"github.com/tendermint/tendermint/p2p"
 	memproto "github.com/tendermint/tendermint/proto/tendermint/mempool"
 	"github.com/tendermint/tendermint/proxy"
@@ -99,10 +100,11 @@ func makeAndConnectReactors(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
+		sidecar := mempoolv0.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
-		reactors[i] = NewReactor(config.Mempool, mempool) // so we dont start the consensus states
+		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
 		reactors[i].SetLogger(logger.With("validator", i))
 	}
 

--- a/mempool/v1/reactor_test.go
+++ b/mempool/v1/reactor_test.go
@@ -308,7 +308,6 @@ func makeAndConnectReactorsEvensSidecar(config *cfg.Config, n int) []*Reactor {
 	return reactors
 }
 
-
 // Sidecar testing utils
 
 type testBundleInfo struct {
@@ -352,4 +351,3 @@ func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testB
 	}
 	return txBytes
 }
-

--- a/mempool/v1/reactor_test.go
+++ b/mempool/v1/reactor_test.go
@@ -1,7 +1,9 @@
 package v1
 
 import (
+	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -17,7 +19,6 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mempool"
-	mempoolv0 "github.com/tendermint/tendermint/mempool/v0"
 	"github.com/tendermint/tendermint/p2p"
 	memproto "github.com/tendermint/tendermint/proto/tendermint/mempool"
 	"github.com/tendermint/tendermint/proxy"
@@ -66,7 +67,7 @@ func TestReactorBroadcastTxsMessage(t *testing.T) {
 		transactions[idx] = tx.tx
 	}
 
-	waitForTxsOnReactors(t, transactions, reactors)
+	waitForTxsOnReactors(t, transactions, reactors, false)
 }
 
 func TestMempoolVectors(t *testing.T) {
@@ -100,7 +101,7 @@ func makeAndConnectReactors(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
-		sidecar := mempoolv0.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
@@ -149,14 +150,18 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, conf *cfg.Config) (*TxMe
 	return mp, func() { os.RemoveAll(conf.RootDir) }
 }
 
-func waitForTxsOnReactors(t *testing.T, txs types.Txs, reactors []*Reactor) {
+func waitForTxsOnReactors(t *testing.T, txs types.Txs, reactors []*Reactor, useSidecar bool) {
 	// wait for the txs in all mempools
 	wg := new(sync.WaitGroup)
 	for i, reactor := range reactors {
 		wg.Add(1)
 		go func(r *Reactor, reactorIndex int) {
 			defer wg.Done()
-			waitForTxsOnReactor(t, txs, r, reactorIndex)
+			if useSidecar {
+				waitForSidecarTxsOnReactor(t, txs, r, reactorIndex)
+			} else {
+				waitForTxsOnReactor(t, txs, r, reactorIndex)
+			}
 		}(reactor, i)
 	}
 
@@ -186,3 +191,165 @@ func waitForTxsOnReactor(t *testing.T, txs types.Txs, reactor *Reactor, reactorI
 			"txs at index %d on reactor %d don't match: %v vs %v", i, reactorIndex, tx, reapedTxs[i])
 	}
 }
+
+func waitForSidecarTxsOnReactor(t *testing.T, txs types.Txs, reactor *Reactor, reactorIndex int) {
+	sidecar := reactor.sidecar
+	for sidecar.Size() < len(txs) {
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	reapedTxs := sidecar.ReapMaxTxs()
+	var i int
+	for _, scTx := range reapedTxs.Txs {
+		assert.Equalf(t, txs[i], scTx,
+			"txs at index %d on reactor %d don't match: %s vs %s", i, reactorIndex, txs[i], scTx)
+		i++
+	}
+}
+
+func TestReactorBroadcastSidecarOnly(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 8
+	reactors := makeAndConnectReactorsEvensSidecar(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors[2:3], true)
+	waitForTxsOnReactors(t, txs, reactors[4:5], true)
+	waitForTxsOnReactors(t, txs, reactors[6:7], true)
+	assert.Equal(t, 0, reactors[1].sidecar.Size())
+	assert.Equal(t, 0, reactors[5].sidecar.Size())
+	assert.Equal(t, 0, reactors[7].sidecar.Size())
+	assert.Equal(t, 0, reactors[3].sidecar.Size())
+}
+
+// Send a bunch of txs to the first reactor's sidecar and wait for them all to
+// be received in the others, IN THE RIGHT ORDER
+func TestReactorBroadcastSidecarTxsMessage(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 2
+	reactors := makeAndConnectReactors(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors, true)
+	reactors[1].sidecar.PrettyPrintBundles()
+}
+
+func TestReactorInsertOutOfOrderThenReap(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 2
+	reactors := makeAndConnectReactors(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors, true)
+	reactors[1].sidecar.PrettyPrintBundles()
+}
+
+// connect N mempool reactors through N switches
+// can add additional logic to set which ones should be treated as sidecar
+// peers in p2p.Connect2Switches, including based on index
+func makeAndConnectReactorsEvensSidecar(config *cfg.Config, n int) []*Reactor {
+	reactors := make([]*Reactor, n)
+	logger := mempoolLogger()
+	for i := 0; i < n; i++ {
+		app := kvstore.NewApplication()
+		cc := proxy.NewLocalClientCreator(app)
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		mempool, cleanup := newMempoolWithApp(cc)
+		defer cleanup()
+
+		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
+		reactors[i].SetLogger(logger.With("validator", i))
+	}
+
+	p2p.MakeConnectedSwitches(config.P2P, n, func(i int, s *p2p.Switch) *p2p.Switch {
+		s.AddReactor("MEMPOOL", reactors[i])
+		return s
+
+	}, p2p.Connect2SwitchesEvensSidecar)
+	return reactors
+}
+
+
+// Sidecar testing utils
+
+type testBundleInfo struct {
+	BundleSize    int64
+	DesiredHeight int64
+	BundleID      int64
+	PeerID        uint16
+}
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
+}
+

--- a/node/node.go
+++ b/node/node.go
@@ -376,6 +376,12 @@ func createMempoolAndSidecarAndMempoolReactor(
 	logger log.Logger,
 ) (mempl.Mempool, p2p.Reactor, mempl.PriorityTxSidecar) {
 
+	sidecar := mempoolv0.NewCListSidecar(
+		state.LastBlockHeight,
+		logger,
+		memplMetrics,
+	)
+
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -391,12 +397,13 @@ func createMempoolAndSidecarAndMempoolReactor(
 		reactor := mempoolv1.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor, nil
+		return mp, reactor, sidecar
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -409,12 +416,6 @@ func createMempoolAndSidecarAndMempoolReactor(
 		)
 
 		mp.SetLogger(logger)
-
-		sidecar := mempoolv0.NewCListSidecar(
-			state.LastBlockHeight,
-			logger,
-			memplMetrics,
-		)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,

--- a/node/node.go
+++ b/node/node.go
@@ -231,7 +231,7 @@ type Node struct {
 	indexerService    *txindex.IndexerService
 	prometheusSrv     *http.Server
 
-	sidecar *mempoolv0.CListPriorityTxSidecar
+	sidecar *mempl.CListPriorityTxSidecar
 }
 
 func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
@@ -376,7 +376,7 @@ func createMempoolAndSidecarAndMempoolReactor(
 	logger log.Logger,
 ) (mempl.Mempool, p2p.Reactor, mempl.PriorityTxSidecar) {
 
-	sidecar := mempoolv0.NewCListSidecar(
+	sidecar := mempl.NewCListSidecar(
 		state.LastBlockHeight,
 		logger,
 		memplMetrics,
@@ -958,7 +958,7 @@ func NewNode(config *cfg.Config,
 		}()
 	}
 
-	typeAssertedSidecar, ok := sidecar.(*mempoolv0.CListPriorityTxSidecar)
+	typeAssertedSidecar, ok := sidecar.(*mempl.CListPriorityTxSidecar)
 	if !ok {
 		logger.Info("[node startup]: Creating node with nil sidecar")
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -248,7 +248,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -258,7 +258,6 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -268,7 +267,6 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 
 	// Make EvidencePool
@@ -357,7 +355,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
 		mempool = mempoolv0.NewCListMempool(config.Mempool,
@@ -366,7 +364,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -376,7 +373,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 
 	// fill the mempool with one txs just below the maximum size

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -248,7 +248,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	sidecar := mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -355,7 +355,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	sidecar := mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
 		mempool = mempoolv0.NewCListMempool(config.Mempool,

--- a/state/execution.go
+++ b/state/execution.go
@@ -108,13 +108,14 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
-	sidecarTxs := make([]*mempl.MempoolTx, 0)
+	var sidecarTxs types.ReapedTxs
 	if blockExec.sidecar != nil {
 		sidecarTxs = blockExec.sidecar.ReapMaxTxs()
 	} else {
 		fmt.Println("Sidecar is nil, not reaping")
 	}
-	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas, sidecarTxs)
+	memplTxs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
+	txs := mempl.CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, maxDataBytes, maxGas)
 
 	return state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 }

--- a/test/maverick/consensus/replay_stubs.go
+++ b/test/maverick/consensus/replay_stubs.go
@@ -23,8 +23,8 @@ func (emptyMempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) 
 	return nil
 }
 func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
-	return types.Txs{}
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs {
+	return types.ReapedTxs{}
 }
 func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
@@ -55,7 +55,7 @@ type emptySidecar struct{}
 var _ mempl.PriorityTxSidecar = emptySidecar{}
 
 func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
-func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+func (emptySidecar) ReapMaxTxs() types.ReapedTxs            { return types.ReapedTxs{} }
 
 func (emptySidecar) Lock()   {}
 func (emptySidecar) Unlock() {}

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -383,7 +383,7 @@ func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
 
 func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 	state sm.State, memplMetrics *mempl.Metrics, logger log.Logger) (p2p.Reactor, mempl.Mempool, mempl.PriorityTxSidecar) {
-	sidecar := mempoolv0.NewCListSidecar(
+	sidecar := mempl.NewCListSidecar(
 		state.LastBlockHeight,
 		logger,
 		memplMetrics,

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -383,6 +383,11 @@ func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
 
 func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 	state sm.State, memplMetrics *mempl.Metrics, logger log.Logger) (p2p.Reactor, mempl.Mempool, mempl.PriorityTxSidecar) {
+	sidecar := mempoolv0.NewCListSidecar(
+		state.LastBlockHeight,
+		logger,
+		memplMetrics,
+	)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
@@ -399,12 +404,13 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 		reactor := mempoolv1.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return reactor, mp, nil
+		return reactor, mp, sidecar
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -417,12 +423,6 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 		)
 
 		mp.SetLogger(logger)
-
-		sidecar := mempoolv0.NewCListSidecar(
-			state.LastBlockHeight,
-			logger,
-			memplMetrics,
-		)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,

--- a/types/tx.go
+++ b/types/tx.go
@@ -158,3 +158,9 @@ func ComputeProtoSizeForTxs(txs []Tx) int64 {
 	pdData := data.ToProto()
 	return int64(pdData.Size())
 }
+
+// Used for combining sidecar and mempl txes
+type ReapedTxs struct {
+	Txs        Txs
+	GasWanteds []int64
+}


### PR DESCRIPTION
- Create new `ReapedTxs` type which is just a `types.Txs` and a `[]int64 GasWanteds`. This is used as the new return type of the mempool and sidecar reap functions.
- Create a new `mempool/mev_reap.go` file with a function that merges sidecar and mempool `ReapedTxs` up to `maxBytes, maxGas`
- Reset v0 mempool to original tendermint v0 mempool
- Add sidecar channel to v1 mempool reactor
- Create and use sidecar in `node.go` regardless of which mempool version is used