### PR TITLE
Initializing v0.34.23 mev tendermint

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - run: echo https://github.com/tendermint/tendermint/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ test/fuzz/**/*.zip
 *.pdf
 *.gz
 *.dvi
-# Python virtual environments
 .venv
+
+coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,16 @@ linters-settings:
     min-confidence: 0
   maligned:
     suggest-new: true
+  # govet:
+  #   check-shadowing: true
+  revive:
+    min-confidence: 0
+  misspell:
+    locale: US
+    ignore-words:
+      - behaviour
+  lll:
+    line-length: 140
 
 run:
   skip-files:

--- a/README.md
+++ b/README.md
@@ -1,175 +1,230 @@
-# Tendermint
+![banner](https://skip-protocol.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F33ea763f-bfa3-4c65-ad35-ad0ee1fd312d%2FGroup_6.png?table=block&id=4e75ce44-3f92-482e-a199-4aa75631706b&spaceId=4ee2f125-c8d3-4d79-9a63-1a260c9b8377&width=2000&userId=&cache=v2)
+# mev-tendermint (.8)
 
-![banner](docs/tendermint-core-image.jpg)
+***The purpose of mev-tendermint is to create a private mempool (the “sidecar”) containing atomic bundles of txs and gossip bundles of transactions specifically to the proposer of the next block.***
 
-[Byzantine-Fault Tolerant][bft] [State Machine Replication][smr]. Or
-[Blockchain], for short.
+---
 
-[![Version][version-badge]][version-url]
-[![API Reference][api-badge]][api-url]
-[![Go version][go-badge]][go-url]
-[![Discord chat][discord-badge]][discord-url]
-[![License][license-badge]][license-url]
-[![Sourcegraph][sg-badge]][sg-url]
+# 👨‍💻 How to Integrate [~10min]
 
-| Branch | Tests                              | Linting                         |
-|--------|------------------------------------|---------------------------------|
-| main   | [![Tests][tests-badge]][tests-url] | [![Lint][lint-badge]][lint-url] |
+**NOTE: if you have any questions/issues with integration, please ask us on our discord:  [https://discord.gg/amAgf9Z39w](https://discord.gg/amAgf9Z39w)**
 
-Tendermint Core is a Byzantine Fault Tolerant (BFT) middleware that takes a
-state transition machine - written in any programming language - and securely
-replicates it on many machines.
+---
 
-For protocol details, refer to the [Tendermint Specification](./spec/README.md).
+## 1. Get an API Key  🔑
 
-For detailed analysis of the consensus protocol, including safety and liveness
-proofs, read our paper, "[The latest gossip on BFT
-consensus](https://arxiv.org/abs/1807.04938)".
+**🚨**  If you don’t already have an API Key, **please get one from the [Skip registration site](https://skip.money/register) 🚨**
 
-## Documentation
+💵 **You can also configure your MEV payments on the site.** Remember - Skip takes no fees 🎉
 
-Complete documentation can be found on the
-[website](https://docs.tendermint.com/).
+---
 
-## Releases
+## 2. Tendermint replacement ♻️
 
-Please do not depend on `main` as your production branch. Use
-[releases](https://github.com/tendermint/tendermint/releases) instead.
+In the `go.mod` file of the directory you use to compile your chain binary, add a line into `replace` to import the correct `mev-tendermint` version.
 
-Tendermint has been in the production of private and public environments, most
-notably the blockchains of the Cosmos Network. we haven't released v1.0 yet
-since we are making breaking changes to the protocol and the APIs. See below for
-more details about [versioning](#versioning).
+🚨  **You can find the correct version of the `replace` you should use here:** [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c) 
 
-In any case, if you intend to run Tendermint in production, we're happy to help.
-You can contact us [over email](mailto:hello@interchain.io) or [join the
-chat](https://discord.gg/cosmosnetwork).
+```tsx
+// ---------------------------------
+replace (
+    // Other stuff...
+    github.com/tendermint/tendermint => github.com/skip-mev/mev-tendermint <USE CORRECT TAG FOR YOUR CHAIN>
+)
+```
 
-More on how releases are conducted can be found [here](./RELEASES.md).
+🚨 **After modifying the `replace` statement, run `go mod tidy` in your base directory**
 
-## Security
+---
 
-To report a security vulnerability, see our [bug bounty
-program](https://hackerone.com/cosmos). For examples of the kinds of bugs we're
-looking for, see [our security policy](SECURITY.md).
+## 3. Peering Setup 🤝
 
-We also maintain a dedicated mailing list for security updates. We will only
-ever use this mailing list to notify you of vulnerabilities and fixes in
-Tendermint Core. You can subscribe [here](http://eepurl.com/gZ5hQD).
+mev-tendermint introduces a new section of config in `config.toml` called `[sidecar].`
 
-## Minimum requirements
+…by the end, the end of your `config.toml` will look something like this (with different string values). **Make sure to include the line `[sidecar]` at the top of this section in `config.toml`.**
 
-| Requirement | Notes             |
-|-------------|-------------------|
-| Go version  | Go 1.18 or higher |
+🚨 **FIND THE CORRECT VALUES TO USE HERE: [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c)** 
 
-### Install
+```bash
+# OTHER CONFIG...
 
-See the [install instructions](./docs/introduction/install.md).
+# **EXAMPLE** below (please use the correct values)
+[sidecar]
+relayer_peer_string = "d1463b730c6e0dcea59db726836aeaff13a8119f@uni-5-sentinel.skip.money:26656"
+relayer_rpc_string = "uni-5-gateway.skip.money"
+api_key = "2314ajinashg2389jfjap"
+personal_peer_ids = "557611c7a7307ce023a7d13486b570282521296d,5740acbf39a9ae59953801fe4997421b6736e091"
+```
 
-### Quick Start
+Here’s an explanation of what these are:
 
-- [Single node](./docs/introduction/quick-start.md)
-- [Local cluster using docker-compose](./docs/tools/docker-compose.md)
-- [Remote cluster using Terraform and Ansible](./docs/tools/terraform-and-ansible.md)
+### `relayer_peer_string`
 
-## Contributing
+- The `p2p@ip:port` for the Skip Sentinel that is used to establish a secret, authenticated handshake between your node and the Skip sentinel
+- For nodes that should not communicate with the sentinel directly (e.g. validator nodes that have sentries), this does not need to be set.
+- **⭐  Find the `relayer_peer_string` here:** [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c)
 
-Please abide by the [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions.
+### `relayer_rpc_string`
 
-Before contributing to the project, please take a look at the [contributing
-guidelines](CONTRIBUTING.md) and the [style guide](STYLE_GUIDE.md). You may also
-find it helpful to read the [specifications](./spec/README.md), and familiarize
-yourself with our [Architectural Decision Records
-(ADRs)](./docs/architecture/README.md) and
-[Request For Comments (RFCs)](./docs/rfc/README.md).
+- The `api` for the Skip Sentinel that is used to register your node
+- For nodes that should not communicate with the sentinel directly (e.g. validator nodes that have sentries), this does not need to be set.
+- **⭐  Find the `relayer_rpc_string` here:** [⚙️ Skip Configurations By Chain](https://www.notion.so/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c)
 
-## Versioning
+### `api_key`
 
-### Semantic Versioning
+- This is the unique string key Skip uses to ensure a node establishing a connection with our relay actually belongs to your validator.
+- If you don't have one, please request one from the Skip team on our **[discord](https://discord.gg/amAgf9Z39w)**
 
-Tendermint uses [Semantic Versioning](http://semver.org/) to determine when and
-how the version changes. According to SemVer, anything in the public API can
-change at any time before version 1.0.0
+### `personal_peer_ids`
 
-To provide some stability to users of 0.X.X versions of Tendermint, the MINOR
-version is used to signal breaking changes across Tendermint's API. This API
-includes all publicly exposed types, functions, and methods in non-internal Go
-packages as well as the types and methods accessible via the Tendermint RPC
-interface.
+- **You only need to set this if you use sentries, otherwise leave empty.**
+- This is the list of peer nodes your node will gossip Skip bundles to after receiving them.
+    - For your validator, this should be the `p2p ids` of all your **sentry nodes**
+    - For your sentry nodes, this should be the `p2p ids` of all your **other** sentry nodes, **and your validator**
+- You can find a node’s p2p id using (on the machine for the node):
 
-Breaking changes to these public APIs will be documented in the CHANGELOG.
+```json
+evmosd tendermint show-node-id --home <HOME_DIR>
+```
 
-### Upgrades
+---
 
-In an effort to avoid accumulating technical debt prior to 1.0.0, we do not
-guarantee that breaking changes (ie. bumps in the MINOR version) will work with
-existing Tendermint blockchains. In these cases you will have to start a new
-blockchain, or write something custom to get the old data into the new chain.
-However, any bump in the PATCH version should be compatible with existing
-blockchain histories.
+## 4. Recompile your binary, and start! 🎉
 
-For more information on upgrading, see [UPGRADING.md](./UPGRADING.md).
+That’s it! After making the changes above, you can recompile your binary (e.g. `evmosd`, probably using `make install`),  and restart your node(s)! You will now begin receiving MEV bundles and higher rewards.
 
-### Supported Versions
+---
 
-Because we are a small core team, we only ship patch updates, including security
-updates, to the most recent minor release and the second-most recent minor
-release. Consequently, we strongly recommend keeping Tendermint up-to-date.
-Upgrading instructions can be found in [UPGRADING.md](./UPGRADING.md).
+# ✍️ Monitoring & Troubleshooting
 
-## Resources
+After you have completed the steps above, you can check you connectivity either via:
 
-### Libraries
+- Check if you are peered with the sentinel by calling `curl http://localhost:26657/status`
+    
+    ```jsx
+     ”is_peered_with_relayer”: true
+    ```
+    
+- Check if you are running `mev-tendermint` by running either:
+    
+    ```bash
+    # by running binary
+    curl -sL localhost:26657/status | jq .result.mev_info
+    
+    # or by checking version detail
+    evmosd version --long | grep mev
+    ```
+    
+- Via the new prometheus metrics exposed on mev-tendermint, in particular `sidecar_relay_connected`
 
-- [Cosmos SDK](http://github.com/cosmos/cosmos-sdk); A framework for building
-  applications in Golang
-- [Tendermint in Rust](https://github.com/informalsystems/tendermint-rs)
-- [ABCI Tower](https://github.com/penumbra-zone/tower-abci)
+---
 
-### Applications
+# ⚙️ Handling Chain Upgrades
 
-- [Cosmos Hub](https://hub.cosmos.network/)
-- [Terra](https://www.terra.money/)
-- [Celestia](https://celestia.org/)
-- [Anoma](https://anoma.network/)
-- [Vocdoni](https://docs.vocdoni.io/)
+Handling chain upgrades is simple:
 
-### Research
+1. Apply the latest patch to your validators & nodes, **without `mev-tendermint`**
+    1. If you have local changes to `go.mod` and `go.sum` that prevent you from pulling the new version, you can run:
+    
+    ```bash
+    git stash
+    git stash apply
+    ```
+    
+    1. to remove them first, then pull again
+2. Recompile your binary with `mev-tendermint` (**same as step 2)**, keeping the same config
+3. Restart your nodes and validators, you’re back up! 🎉
 
-- [The latest gossip on BFT consensus](https://arxiv.org/abs/1807.04938)
-- [Master's Thesis on Tendermint](https://atrium.lib.uoguelph.ca/xmlui/handle/10214/9769)
-- [Original Whitepaper: "Tendermint: Consensus Without Mining"](https://tendermint.com/static/docs/tendermint.pdf)
-- [Tendermint Core Blog](https://medium.com/tendermint/tagged/tendermint-core)
-- [Cosmos Blog](https://blog.cosmos.network/tendermint/home)
+---
 
-## Join us!
+# 🤿 About `mev-tendermint`
 
-Tendermint Core is maintained by [Interchain GmbH](https://interchain.berlin).
-If you'd like to work full-time on Tendermint Core,
-[we're hiring](https://interchain-gmbh.breezy.hr/)!
+## ✅  Design
 
-Funding for Tendermint Core development comes primarily from the
-[Interchain Foundation](https://interchain.io), a Swiss non-profit. The
-Tendermint trademark is owned by [Tendermint Inc.](https://tendermint.com), the
-for-profit entity that also maintains [tendermint.com](https://tendermint.com).
+The design goals of MEV-Tendermint is to allow & preserve:
 
-[bft]: https://en.wikipedia.org/wiki/Byzantine_fault_tolerance
-[smr]: https://en.wikipedia.org/wiki/State_machine_replication
-[Blockchain]: https://en.wikipedia.org/wiki/Blockchain
-[version-badge]: https://img.shields.io/github/tag/tendermint/tendermint.svg
-[version-url]: https://github.com/tendermint/tendermint/releases/latest
-[api-badge]: https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
-[api-url]: https://pkg.go.dev/github.com/tendermint/tendermint
-[go-badge]: https://img.shields.io/badge/go-1.18-blue.svg
-[go-url]: https://github.com/moovweb/gvm
-[discord-badge]: https://img.shields.io/discord/669268347736686612.svg
-[discord-url]: https://discord.gg/cosmosnetwork
-[license-badge]: https://img.shields.io/github/license/tendermint/tendermint.svg
-[license-url]: https://github.com/tendermint/tendermint/blob/main/LICENSE
-[sg-badge]: https://sourcegraph.com/github.com/tendermint/tendermint/-/badge.svg
-[sg-url]: https://sourcegraph.com/github.com/tendermint/tendermint?badge
-[tests-url]: https://github.com/tendermint/tendermint/actions/workflows/tests.yml
-[tests-badge]: https://github.com/tendermint/tendermint/actions/workflows/tests.yml/badge.svg?branch=main
-[lint-badge]: https://github.com/tendermint/tendermint/actions/workflows/lint.yml/badge.svg
-[lint-url]: https://github.com/tendermint/tendermint/actions/workflows/lint.yml
+1. 🔒  **Privacy** for users submitting bundles
+2. 🎁  **Atomicity** for bundles of transactions
+3. 🐎  **Priority** guaranteed for highest paying bundles
+4. 🏛  **No new security assumptions** for validators and nodes running MEV-Tendermint, including removing the need for ingress or egress for locked-down validators. No new network assumptions are made
+5. 🔄  **On-chain transaction submission** via gossip, no need for off-chain submission like HTTP endpoints, endpoint querying, etc
+6. 💨  **Impossible to slow down block time**, i.e. no part of mev-tendermint introduces consensus delays
+
+## 🔎  Basic Functionality Overview
+
+🏦  **Auction**
+
+- Prior to the creation of the first proposal for height `n+1` , the Skip Sentinel infrastructure selects an auction-winning bundle (or bundles) to include at the top of block `n+1`
+- The auction-winning bundle is defined as the bundle that pays the highest gas price ( sum(txFee)/sum(gasWanted) ) and doesn’t include any reverting transactions
+- The sentinel ensures it’s simulations of the bundle are accurate by simulating it against the version of state where it will actually run (by optimistically applying the proposals produced for height `n` )
+
+🗣️  **Gossip**
+
+- Before the first proposal for height `n+1` is created, the Skip sentinel gossips the auction-winning bundle(s) to whichever nodes belonging to that proposer it can access (e.g. sentries if the validator is using a sentry configuration, or validator replicas if it’s using horcrux)
+- The nodes that receive the winning bundle(s) gossip it to the other nodes belonging to that proposer to ensure the bundle(s) reach the validator
+- This selective gossiping is powered by new config options (`personal_peer_ids`) and takes place over a new channel, but it is secured using the same authentication handshake Tendermint uses to secure all other forms of p2p communication
+
+[reinforce that we have different channels on the same reactor]
+
+🏒  **Handling Transactions**
+
+- Ordinary transactions received over traditional gossip are handled exactly the same way they are today in the mempool
+- Transactions received as part of bundles sent from the Skip sentinel are handled and stored in a new data structure called the `sidecar`
+- These transactions have additional metadata about the bundle in which they should be included (e.g. bundleOrder, bundleSize). The sidecar uses this data to reconstruct bundles as it receives individual transactions over gossip
+
+[reinforce that we have a new transaction data structure]
+
+🚜  **Reaping** 
+
+- On reap, mev-tendermint first checks whether there are any fully-constructed bundles in the sidecar then reaps these first.
+- Next, it reaps from the ordinary mempool, with some additional checks to ensure that transactions reaped from the sidecar don’t get reaped again if they are also present in the standard mempool
+
+[reinforce reaping of bundle goes to top if available]
+
+## 🧱 Components
+
+### **#1 The Sidecar**
+
+- A separate, private mempool that respects `bundles` of transactions
+    - Relevant files: `mempool/clist_sidecar.go`
+- Has **selective gossiping**, meaning it only gossips:
+    - Over its own `SidecarChannel`
+    - **Only** to peers that are added as its `personal_peers`
+        - In practice, `personal_peers` for each node are set to be:
+            - Sentry node →  **Skip sentinel** & **the other nodes you’re running that the sentry is aware of (e.g. validator or a layer of sentries closer to the validator)**
+            - Validator node → **only its sentries**
+
+**#2 The Mempool Reactor**
+
+- The mempool reactor now supports a `SidecarChannel` over which only gossip for `SidecarTxs` can be handled
+    - Relevant files: `mempool/reactor.go`
+    - `SidecarTxs` have new metadata that is transmitted over gossip, including
+        - `BundleId` - the **global** order of the bundle this `SidecarTx` is in, per height
+        - `BundleOrder` - the **local** order of this `SidecarTx` within its bundle
+        - `DesiredHeight` - the height of the bundle this `SidecarTx` was submitted for
+        - `BundleSize` - the total size of the bundle this `SidecarcarTx` is in
+        - `TotalFee` - the total fee of the bundle this `SidecarTx` is in
+    - This metadata is submitted at a transaction level as **tendermint currently is not designed to broadcast batches of transactions**
+
+**#3 Selective Reaping**
+
+- The regular mempool now considers `sidecarTxs` (i.e. bundles) in addition to regular txs, and orders the former before the latter
+    - Relevant files: `mempool/clist_mempool.go`, `state/execution.go`
+
+---
+
+## ䷾ Metrics
+
+`mev-tendermint` exposes new **[prometheus metrics](https://docs.tendermint.com/v0.34/tendermint-core/metrics.html)** that you can use to supplement your dashboards (e.g. with Grafana)
+
+**Metrics exposed:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| sidecar_size_bytes | Histogram | Histogram of sidecar mev transaction sizes, in bytes |
+| sidecar_size | Gauge | Size of the sidecar |
+| sidecar_num_bundles_total | Counter | Number of MEV bundles received by the sidecar in total |
+| sidecar_num_bundles_last_block | Gauge | Number of mev bundles received during the last block |
+| sidecar_num_mev_txs_total | Counter | Number of mev transactions added in total |
+| sidecar_num_mev_txs_last_block | Gauge | Number of mev transactions received by sidecar in the last block |
+| sidecar_relay_connected | Gauge | Whether or not a node is connected to the relay, 1 if connected, 0 if not. |

--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ The design goals of MEV-Tendermint is to allow & preserve:
 | sidecar_num_bundles_last_block | Gauge | Number of mev bundles received during the last block |
 | sidecar_num_mev_txs_total | Counter | Number of mev transactions added in total |
 | sidecar_num_mev_txs_last_block | Gauge | Number of mev transactions received by sidecar in the last block |
-| sidecar_relay_connected | Gauge | Whether or not a node is connected to the relay, 1 if connected, 0 if not. |
+| p2p_relay_connected | Gauge | Whether or not a node is connected to the relay, 1 if connected, 0 if not. |

--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -1217,6 +1217,7 @@ func (m *RequestApplySnapshotChunk) GetSender() string {
 
 type Response struct {
 	// Types that are valid to be assigned to Value:
+	//
 	//	*Response_Exception
 	//	*Response_Echo
 	//	*Response_Flush

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -91,7 +91,7 @@ func newBlockchainReactor(
 		DiscardABCIResponses: false,
 	})
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
-		mock.Mempool{}, sm.EmptyEvidencePool{})
+		mock.Mempool{}, sm.EmptyEvidencePool{}, mock.PriorityTxSidecar{})
 	if err = stateStore.Save(state); err != nil {
 		panic(err)
 	}

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -123,7 +123,7 @@ func newBlockchainReactor(
 		DiscardABCIResponses: false,
 	})
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
-		mock.Mempool{}, sm.EmptyEvidencePool{})
+		mock.Mempool{}, sm.EmptyEvidencePool{}, mock.PriorityTxSidecar{})
 	if err = stateStore.Save(state); err != nil {
 		panic(err)
 	}

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -40,9 +40,10 @@ func (mp mockPeer) ID() p2p.ID           { return mp.id }
 func (mp mockPeer) RemoteIP() net.IP     { return net.IP{} }
 func (mp mockPeer) RemoteAddr() net.Addr { return &net.TCPAddr{IP: mp.RemoteIP(), Port: 8800} }
 
-func (mp mockPeer) IsOutbound() bool   { return true }
-func (mp mockPeer) IsPersistent() bool { return true }
-func (mp mockPeer) CloseConn() error   { return nil }
+func (mp mockPeer) IsOutbound() bool    { return true }
+func (mp mockPeer) IsPersistent() bool  { return true }
+func (mp mockPeer) IsSidecarPeer() bool { return true }
+func (mp mockPeer) CloseConn() error    { return nil }
 
 func (mp mockPeer) NodeInfo() p2p.NodeInfo {
 	return p2p.DefaultNodeInfo{
@@ -146,7 +147,8 @@ func newTestReactor(p testReactorParams) *BlockchainReactor {
 		stateStore := sm.NewStore(db, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		appl = sm.NewBlockExecutor(stateStore, p.logger, proxyApp.Consensus(), mock.Mempool{}, sm.EmptyEvidencePool{})
+		appl = sm.NewBlockExecutor(stateStore, p.logger, proxyApp.Consensus(),
+			mock.Mempool{}, sm.EmptyEvidencePool{}, mock.PriorityTxSidecar{})
 		if err = stateStore.Save(state); err != nil {
 			panic(err)
 		}
@@ -534,7 +536,7 @@ func newReactorStore(
 	},
 	)
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
-		mock.Mempool{}, sm.EmptyEvidencePool{})
+		mock.Mempool{}, sm.EmptyEvidencePool{}, mock.PriorityTxSidecar{})
 	if err = stateStore.Save(state); err != nil {
 		panic(err)
 	}

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -53,6 +53,22 @@ func ParseConfig(cmd *cobra.Command) (*cfg.Config, error) {
 	if err := conf.ValidateBasic(); err != nil {
 		return nil, fmt.Errorf("error in config file: %v", err)
 	}
+	// Add auction relayer to config if not present and set
+	if len(conf.Sidecar.RelayerPeerString) > 0 {
+		relayerID := strings.Split(conf.Sidecar.RelayerPeerString, "@")[0]
+		if !strings.Contains(conf.P2P.PrivatePeerIDs, relayerID) {
+			// safety check to not blow away existing private peers if any
+			if len(conf.P2P.PrivatePeerIDs) > 0 {
+				if conf.P2P.PrivatePeerIDs[len(conf.P2P.PrivatePeerIDs)-1:] == "," {
+					conf.P2P.PrivatePeerIDs = conf.P2P.PrivatePeerIDs + relayerID
+				} else {
+					conf.P2P.PrivatePeerIDs = conf.P2P.PrivatePeerIDs + "," + relayerID
+				}
+			} else {
+				conf.P2P.PrivatePeerIDs = relayerID
+			}
+		}
+	}
 	return conf, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	Storage         *StorageConfig         `mapstructure:"storage"`
 	TxIndex         *TxIndexConfig         `mapstructure:"tx_index"`
 	Instrumentation *InstrumentationConfig `mapstructure:"instrumentation"`
+	Sidecar         *SidecarConfig         `mapstructure:"sidecar"`
 }
 
 // DefaultConfig returns a default configuration for a Tendermint node
@@ -92,6 +93,7 @@ func DefaultConfig() *Config {
 		Storage:         DefaultStorageConfig(),
 		TxIndex:         DefaultTxIndexConfig(),
 		Instrumentation: DefaultInstrumentationConfig(),
+		Sidecar:         DefaultSidecarConfig(),
 	}
 }
 
@@ -108,6 +110,7 @@ func TestConfig() *Config {
 		Storage:         TestStorageConfig(),
 		TxIndex:         TestTxIndexConfig(),
 		Instrumentation: TestInstrumentationConfig(),
+		Sidecar:         TestSidecarConfig(),
 	}
 }
 
@@ -118,6 +121,7 @@ func (cfg *Config) SetRoot(root string) *Config {
 	cfg.P2P.RootDir = root
 	cfg.Mempool.RootDir = root
 	cfg.Consensus.RootDir = root
+	cfg.Sidecar.RootDir = root
 	return cfg
 }
 
@@ -147,6 +151,9 @@ func (cfg *Config) ValidateBasic() error {
 	}
 	if err := cfg.Instrumentation.ValidateBasic(); err != nil {
 		return fmt.Errorf("error in [instrumentation] section: %w", err)
+	}
+	if err := cfg.Sidecar.ValidateBasic(); err != nil {
+		return fmt.Errorf("error in [Sidecar] section: %w", err)
 	}
 	return nil
 }
@@ -1070,6 +1077,37 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	if cfg.DoubleSignCheckHeight < 0 {
 		return errors.New("double_sign_check_height can't be negative")
 	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+// SidecarConfig
+
+// Sidecar defines configuration for gossiping the private sidecar
+// mempool among the relayer and the nodes that belong to a particular proposer
+type SidecarConfig struct {
+	RootDir           string `mapstructure:"home"`
+	RelayerRPCString  string `mapstructure:"relayer_rpc_string"`
+	RelayerPeerString string `mapstructure:"relayer_peer_string"`
+
+	PersonalPeerIDs string `mapstructure:"personal_peer_ids"`
+	APIKey          string `mapstructure:"api_key"`
+}
+
+func DefaultSidecarConfig() *SidecarConfig {
+	return &SidecarConfig{}
+}
+
+func TestSidecarConfig() *SidecarConfig {
+	return &SidecarConfig{
+		RelayerRPCString:  "test-api.skip.money",
+		RelayerPeerString: "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656",
+		APIKey:            "api-key",
+	}
+}
+
+// no-op validation
+func (s *SidecarConfig) ValidateBasic() error {
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.NotNil(cfg.P2P)
 	assert.NotNil(cfg.Mempool)
 	assert.NotNil(cfg.Consensus)
+	assert.NotNil(cfg.Sidecar)
 
 	// check the root dir stuff...
 	cfg.SetRoot("/foo")

--- a/config/toml.go
+++ b/config/toml.go
@@ -534,6 +534,19 @@ max_open_connections = {{ .Instrumentation.MaxOpenConnections }}
 
 # Instrumentation namespace
 namespace = "{{ .Instrumentation.Namespace }}"
+
+#######################################################
+###       Sidecar Configuration Options          ###
+#######################################################
+# comma separated list of peer ids that represent the nodes
+# you run that this node is aware of / can communicate with
+# (This allows private sidecar gossiping to ensure only your validator and the other
+# nodes in your network receive auction-winning
+# txs when when your validator is the proposer)
+personal_peer_ids = "{{ .Sidecar.PersonalPeerIDs }}"
+relayer_peer_string = "{{ .Sidecar.RelayerPeerString }}"
+relayer_rpc_string = "{{ .Sidecar.RelayerRPCString }}"
+api_key = "{{ .Sidecar.APIKey }}"
 `
 
 /****** these are for test settings ***********/

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -64,7 +64,7 @@ func TestEnsureTestRoot(t *testing.T) {
 }
 
 func checkConfig(configFile string) bool {
-	var valid bool
+	valid := true
 
 	// list of words we expect in the config
 	elems := []string{
@@ -82,12 +82,14 @@ func checkConfig(configFile string) bool {
 		"propose",
 		"max",
 		"genesis",
+		"skip",
+		"relayer_rpc_string",
+		"relayer_peer_string",
+		"personal_peer_ids",
 	}
 	for _, e := range elems {
 		if !strings.Contains(configFile, e) {
 			valid = false
-		} else {
-			valid = true
 		}
 	}
 	return valid

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -72,7 +72,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
-		var sidecar mempl.PriorityTxSidecar
+		sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), mempl.NopMetrics())
 
 		switch thisConfig.Mempool.Version {
 		case cfg.MempoolV0:
@@ -81,7 +81,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				state.LastBlockHeight,
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), mempl.NopMetrics())
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -90,7 +89,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
-			sidecar = nil
 		}
 
 		if thisConfig.Consensus.WaitForTxs() {

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -72,6 +72,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
+		var sidecar mempl.PriorityTxSidecar
 
 		switch thisConfig.Mempool.Version {
 		case cfg.MempoolV0:
@@ -80,6 +81,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				state.LastBlockHeight,
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), mempl.NopMetrics())
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -88,6 +90,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
+			sidecar = nil
 		}
 
 		if thisConfig.Consensus.WaitForTxs() {
@@ -101,7 +104,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		evpool.SetLogger(logger.With("module", "evidence"))
 
 		// Make State
-		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
+		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, sidecar)
 		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 		cs.SetLogger(cs.Logger)
 		// set private validator

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -52,7 +52,7 @@ type cleanupFunc func()
 var (
 	config                *cfg.Config // NOTE: must be reset for each _test.go file
 	consensusReplayConfig *cfg.Config
-	ensureTimeout         = time.Millisecond * 200
+	ensureTimeout         = time.Millisecond * 1000
 )
 
 func ensureDir(dir string, mode os.FileMode) {
@@ -399,6 +399,7 @@ func newStateWithConfigAndBlockStore(
 
 	// Make Mempool
 	var mempool mempl.Mempool
+	var sidecar mempl.PriorityTxSidecar
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -408,6 +409,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,
@@ -418,6 +420,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
+		sidecar = nil
 	}
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
@@ -434,7 +437,7 @@ func newStateWithConfigAndBlockStore(
 		panic(err)
 	}
 
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, sidecar)
 	cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 	cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 	cs.SetPrivValidator(pv)

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -399,7 +399,7 @@ func newStateWithConfigAndBlockStore(
 
 	// Make Mempool
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -409,7 +409,7 @@ func newStateWithConfigAndBlockStore(
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
+
 	case cfg.MempoolV1:
 		logger := consensusLogger()
 		mempool = mempoolv1.NewTxMempool(logger,
@@ -420,7 +420,6 @@ func newStateWithConfigAndBlockStore(
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -173,7 +173,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, nil)
+			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1).Txs
 			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -173,7 +173,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1)
+			txs := assertMempool(cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, nil)
 			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -166,7 +166,7 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
-		var sidecar mempl.PriorityTxSidecar
+		sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 		switch config.Mempool.Version {
 		case cfg.MempoolV0:
@@ -176,7 +176,6 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv0.WithMetrics(memplMetrics),
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -186,7 +185,6 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
-			sidecar = nil
 		}
 		if thisConfig.Consensus.WaitForTxs() {
 			mempool.EnableTxsAvailable()

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -166,6 +166,7 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		// Make Mempool
 		var mempool mempl.Mempool
+		var sidecar mempl.PriorityTxSidecar
 
 		switch config.Mempool.Version {
 		case cfg.MempoolV0:
@@ -175,6 +176,7 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv0.WithMetrics(memplMetrics),
 				mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
+			sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 		case cfg.MempoolV1:
 			mempool = mempoolv1.NewTxMempool(logger,
 				config.Mempool,
@@ -184,6 +186,7 @@ func TestReactorWithEvidence(t *testing.T) {
 				mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 				mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 			)
+			sidecar = nil
 		}
 		if thisConfig.Consensus.WaitForTxs() {
 			mempool.EnableTxsAvailable()
@@ -202,7 +205,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		evpool2 := sm.EmptyEvidencePool{}
 
 		// Make State
-		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
+		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, sidecar)
 		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool2)
 		cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 		cs.SetPrivValidator(pv)

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -496,7 +496,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 
 	// Use stubs for both mempool and evidence pool since no transactions nor
 	// evidence are needed here - block already exists.
-	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp, emptyMempool{}, sm.EmptyEvidencePool{})
+	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp, emptyMempool{}, sm.EmptyEvidencePool{}, emptySidecar{})
 	blockExec.SetEventBus(h.eventBus)
 
 	var err error

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -329,8 +329,8 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 		tmos.Exit(fmt.Sprintf("Error on handshake: %v", err))
 	}
 
-	mempool, evpool := emptyMempool{}, sm.EmptyEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	mempool, evpool, sidecar := emptyMempool{}, sm.EmptyEvidencePool{}, emptySidecar{}
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, sidecar)
 
 	consensusState := NewState(csConfig, state.Copy(), blockExec,
 		blockStore, mempool, evpool)

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -27,8 +27,10 @@ func (txmp emptyMempool) RemoveTxByKey(txKey types.TxKey) error {
 	return nil
 }
 
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (emptyMempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
+	return types.Txs{}
+}
+func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
 	_ int64,
 	_ types.Txs,
@@ -49,6 +51,37 @@ func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }
 
 func (emptyMempool) InitWAL() error { return nil }
 func (emptyMempool) CloseWAL()      {}
+
+//-----------------------------------------------------------------------------
+
+type emptySidecar struct{}
+
+var _ mempl.PriorityTxSidecar = emptySidecar{}
+
+func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
+func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+
+func (emptySidecar) Lock()   {}
+func (emptySidecar) Unlock() {}
+
+func (emptySidecar) HeightForFiringAuction() int64 { return 0 }
+
+func (emptySidecar) Flush() {}
+func (emptySidecar) Update(
+	blockHeight int64,
+	blockTxs types.Txs,
+	_ []*abci.ResponseDeliverTx,
+) error {
+	return nil
+}
+
+func (emptySidecar) TxsAvailable() <-chan struct{} { return make(chan struct{}) }
+func (emptySidecar) EnableTxsAvailable()           {}
+
+func (emptySidecar) Size() int       { return 0 }
+func (emptySidecar) TxsBytes() int64 { return 0 }
+
+func (emptySidecar) GetLastBundleHeight() int64 { return 0 }
 
 //-----------------------------------------------------------------------------
 // mockProxyApp uses ABCIResponses to give the right results.

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -27,8 +27,8 @@ func (txmp emptyMempool) RemoveTxByKey(txKey types.TxKey) error {
 	return nil
 }
 
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
-	return types.Txs{}
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs {
+	return types.ReapedTxs{}
 }
 func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
@@ -59,7 +59,7 @@ type emptySidecar struct{}
 var _ mempl.PriorityTxSidecar = emptySidecar{}
 
 func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
-func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+func (emptySidecar) ReapMaxTxs() types.ReapedTxs            { return types.ReapedTxs{} }
 
 func (emptySidecar) Lock()   {}
 func (emptySidecar) Unlock() {}

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -314,6 +314,7 @@ const (
 var (
 	mempool = emptyMempool{}
 	evpool  = sm.EmptyEvidencePool{}
+	sidecar = emptySidecar{}
 
 	sim testSim
 )
@@ -789,7 +790,7 @@ func testHandshakeReplay(t *testing.T, config *cfg.Config, nBlocks int, mode uin
 
 func applyBlock(stateStore sm.Store, st sm.State, blk *types.Block, proxyApp proxy.AppConns) sm.State {
 	testPartSize := types.BlockPartSizeBytes
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, sidecar)
 
 	blkID := types.BlockID{Hash: blk.Hash(), PartSetHeader: blk.MakePartSet(testPartSize).Header()}
 	newState, _, err := blockExec.ApplyBlock(st, blkID, blk)

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -84,7 +84,8 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	})
 	mempool := emptyMempool{}
 	evpool := sm.EmptyEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	sidecar := emptySidecar{}
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, sidecar)
 	consensusState := NewState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)

--- a/evidence/mocks/block_store.go
+++ b/evidence/mocks/block_store.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	types "github.com/tendermint/tendermint/types"
 )
 
@@ -59,13 +58,13 @@ func (_m *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	return r0
 }
 
-type NewBlockStoreT interface {
+type mockConstructorTestingTNewBlockStore interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBlockStore(t NewBlockStoreT) *BlockStore {
+func NewBlockStore(t mockConstructorTestingTNewBlockStore) *BlockStore {
 	mock := &BlockStore{}
 	mock.Mock.Test(t)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/btcsuite/btcd v0.22.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/bufbuild/buf v1.9.0
-	github.com/cosmos/gogoproto v1.4.2
 	github.com/creachadair/taskgroup v0.3.2
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/go-kit/kit v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
-github.com/cosmos/gogoproto v1.4.2 h1:UeGRcmFW41l0G0MiefWhkPEVEwvu78SZsHBvI78dAYw=
-github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/light/rpc/mocks/light_client.go
+++ b/light/rpc/mocks/light_client.go
@@ -100,13 +100,13 @@ func (_m *LightClient) VerifyLightBlockAtHeight(ctx context.Context, height int6
 	return r0, r1
 }
 
-type NewLightClientT interface {
+type mockConstructorTestingTNewLightClient interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewLightClient creates a new instance of LightClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLightClient(t NewLightClientT) *LightClient {
+func NewLightClient(t mockConstructorTestingTNewLightClient) *LightClient {
 	mock := &LightClient{}
 	mock.Mock.Test(t)
 

--- a/mempool/clist_sidecar.go
+++ b/mempool/clist_sidecar.go
@@ -375,14 +375,14 @@ func (sc *CListPriorityTxSidecar) Update(
 		if e, ok := sc.txsMap.Load(tx.Key()); ok {
 			if deliverTxResponses[i].Code == abci.CodeTypeOK {
 				sc.logger.Debug(
-					"removed valid commited tx from sidecar",
+					"removed valid committed tx from sidecar",
 					"tx", tx,
 					"mempool updated height", height,
 					"sidecar total size", sc.Size(),
 				)
 			} else {
 				sc.logger.Debug(
-					"removed invalid commited tx from sidecar",
+					"removed invalid committed tx from sidecar",
 					"tx", tx,
 					"mempool updated height", height,
 					"sidecar total size", sc.Size(),
@@ -400,7 +400,7 @@ func (sc *CListPriorityTxSidecar) Update(
 		scTx := e.Value.(*SidecarTx)
 		if scTx.DesiredHeight <= height {
 			sc.logger.Debug(
-				"removed uncommited tx from sidecar",
+				"removed uncommitted tx from sidecar",
 				"tx", scTx.Tx,
 				"tx desired height", scTx.DesiredHeight,
 				"mempool updated height", height,

--- a/mempool/clist_sidecar_test.go
+++ b/mempool/clist_sidecar_test.go
@@ -33,28 +33,6 @@ func addNumBundlesToSidecar(t *testing.T, sidecar PriorityTxSidecar, numBundles 
 	return txs
 }
 
-func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
-	bInfo := testBundleInfo{BundleSize: int64(len(txs)), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
-	for i := 0; i < len(txs); i++ {
-		err := sidecar.AddTx(txs[i], TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
-			BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: int64(i)})
-		if err != nil {
-			t.Error(err)
-		}
-	}
-	return txs
-}
-
-func addNumTxsToSidecarOneBundle(t *testing.T, sidecar PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
-	txs := make(types.Txs, numTxs)
-	bInfo := testBundleInfo{BundleSize: int64(numTxs), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
-	for i := 0; i < numTxs; i++ {
-		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
-		txs = append(txs, txBytes)
-	}
-	return txs
-}
-
 func addTxToSidecar(t *testing.T, sidecar PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
 	txInfo := TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
 		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
@@ -241,7 +219,6 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 	}
 
 	// 4. Insert three successful bundles out of order
-	//nolint:dupl
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    3,
@@ -325,7 +302,6 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 	}
 
 	// 5. Multiple unsuccessful bundles, nothing reaped
-	//nolint:dupl
 	{
 		// size not filled
 		bInfo := testBundleInfo{

--- a/mempool/clist_sidecar_test.go
+++ b/mempool/clist_sidecar_test.go
@@ -1,36 +1,42 @@
-package v0
+package mempool
 
 import (
 	"crypto/rand"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/mempool"
-	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
 )
 
-func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+type testBundleInfo struct {
+	BundleSize    int64
+	DesiredHeight int64
+	BundleID      int64
+	PeerID        uint16
+}
+
+func addNumBundlesToSidecar(t *testing.T, sidecar PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
 	totalTxsCount := 0
 	txs := make(types.Txs, 0)
 	for i := 0; i < numBundles; i++ {
 		totalTxsCount += int(bundleSize)
 		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
-			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+			PeerID: UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
 		txs = append(txs, newTxs...)
 	}
 	return txs
 }
 
-func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
+func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
 	bInfo := testBundleInfo{BundleSize: int64(len(txs)), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
 	for i := 0; i < len(txs); i++ {
-		err := sidecar.AddTx(txs[i], mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		err := sidecar.AddTx(txs[i], TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
 			BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: int64(i)})
 		if err != nil {
 			t.Error(err)
@@ -39,7 +45,7 @@ func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSi
 	return txs
 }
 
-func addNumTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
+func addNumTxsToSidecarOneBundle(t *testing.T, sidecar PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
 	txs := make(types.Txs, numTxs)
 	bInfo := testBundleInfo{BundleSize: int64(numTxs), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
 	for i := 0; i < numTxs; i++ {
@@ -49,8 +55,8 @@ func addNumTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar
 	return txs
 }
 
-func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
-	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+func addTxToSidecar(t *testing.T, sidecar PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
 		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
 	txBytes := make([]byte, 20)
 	_, err := rand.Read(txBytes)
@@ -63,7 +69,7 @@ func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testB
 	return txBytes
 }
 
-func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+func createSidecarBundleAndTxs(t *testing.T, sidecar PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
 	txs := make(types.Txs, bInfo.BundleSize)
 	for i := 0; i < int(bInfo.BundleSize); i++ {
 		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
@@ -72,7 +78,7 @@ func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, 
 	return txs
 }
 
-func addBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bundles []testBundleInfo, peerID uint16) {
+func addBundlesToSidecar(t *testing.T, sidecar PriorityTxSidecar, bundles []testBundleInfo, peerID uint16) {
 	for _, bundle := range bundles {
 		// createSidecarBundleWithTxs(t, sidecar, bundle.BundleSize, peerID, bundle.BundleID, bundle.DesiredHeight)
 		createSidecarBundleAndTxs(t, sidecar, bundle)
@@ -80,16 +86,13 @@ func addBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bundle
 }
 
 func TestSidecarUpdate(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	// 1. Flushes the sidecar
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -98,7 +101,7 @@ func TestSidecarUpdate(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -115,10 +118,7 @@ func TestSidecarUpdate(t *testing.T) {
 }
 
 func TestSidecarTxsAvailable(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 	sidecar.EnableTxsAvailable()
 
 	timeoutMS := 500
@@ -127,7 +127,7 @@ func TestSidecarTxsAvailable(t *testing.T) {
 	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 
 	// send a bunch of txs, it should only fire once
-	txs := addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	txs := addNumBundlesToSidecar(t, sidecar, 100, 10, UnknownPeerID)
 	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 
@@ -137,7 +137,7 @@ func TestSidecarTxsAvailable(t *testing.T) {
 	txs = txs[50:]
 
 	// send a bunch more txs. we already fired for this height so it shouldnt fire again
-	moreTxs := addNumBundlesToSidecar(t, sidecar, 50, 10, mempool.UnknownPeerID)
+	moreTxs := addNumBundlesToSidecar(t, sidecar, 50, 10, UnknownPeerID)
 	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 
 	// now call update with all the txs. it should not fire as there are no txs left
@@ -148,23 +148,20 @@ func TestSidecarTxsAvailable(t *testing.T) {
 	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 
 	// send a bunch more txs, it should only fire once
-	addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	addNumBundlesToSidecar(t, sidecar, 100, 10, UnknownPeerID)
 	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
 }
 
 // TODO: shorten
 func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	// 1. Inserted out of order, but sequential, but bundleSize 1, so should get one tx
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    1,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -173,7 +170,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    1,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -182,7 +179,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		sidecar.PrettyPrintBundles()
 
-		txs := sidecar.ReapMaxTxs()
+		txs := sidecar.ReapMaxTxs().Txs
 		assert.Equal(t, 1, len(txs), "Got %d txs, expected %d",
 			len(txs), 1)
 
@@ -193,7 +190,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -202,14 +199,14 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
 		bundleOrder = 0
 		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
 
-		txs := sidecar.ReapMaxTxs()
+		txs := sidecar.ReapMaxTxs().Txs
 		assert.Equal(t, 2, len(txs), "Got %d txs, expected %d",
 			len(txs), 2)
 
@@ -220,7 +217,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    5,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -229,14 +226,14 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    5,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
 		bundleOrder = 1
 		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
 
-		txs := sidecar.ReapMaxTxs()
+		txs := sidecar.ReapMaxTxs().Txs
 		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
 			len(txs), 0)
 
@@ -248,7 +245,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 	{
 		bInfo := testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      2,
 		}
@@ -257,7 +254,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      2,
 		}
@@ -266,7 +263,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      2,
 		}
@@ -277,7 +274,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -286,7 +283,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -297,7 +294,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      1,
 		}
@@ -306,21 +303,21 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      1,
 		}
 		bundleOrder = 0
 		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
 
-		txs := sidecar.ReapMaxTxs()
+		txs := sidecar.ReapMaxTxs().Txs
 		assert.Equal(t, 7, len(txs), "Got %d txs, expected %d",
 			len(txs), 7)
 		sidecar.PrettyPrintBundles()
 
 		fmt.Println("TXS FROM REAP ----------")
 		for _, memTx := range txs {
-			fmt.Println(memTx.Tx.String())
+			fmt.Println(memTx.String())
 		}
 		fmt.Println("----------")
 
@@ -333,7 +330,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 		// size not filled
 		bInfo := testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      2,
 		}
@@ -342,7 +339,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      2,
 		}
@@ -354,7 +351,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 		// wrong orders
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -363,7 +360,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -372,7 +369,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    3,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 1,
 			BundleID:      0,
 		}
@@ -384,7 +381,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 		// wrong heights
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 2,
 			BundleID:      1,
 		}
@@ -393,21 +390,21 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 
 		bInfo = testBundleInfo{
 			BundleSize:    2,
-			PeerID:        mempool.UnknownPeerID,
+			PeerID:        UnknownPeerID,
 			DesiredHeight: 0,
 			BundleID:      1,
 		}
 		bundleOrder = 0
 		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
 
-		txs := sidecar.ReapMaxTxs()
+		txs := sidecar.ReapMaxTxs().Txs
 		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
 			len(txs), 0)
 		sidecar.PrettyPrintBundles()
 
 		fmt.Println("TXS FROM REAP ----------")
 		for _, memTx := range txs {
-			fmt.Println(memTx.Tx.String())
+			fmt.Println(memTx.String())
 		}
 		fmt.Println("----------")
 
@@ -416,10 +413,7 @@ func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
 }
 
 func TestBasicAddMultipleBundles(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	tests := []struct {
 		numBundlesTxsToCreate int
@@ -432,7 +426,7 @@ func TestBasicAddMultipleBundles(t *testing.T) {
 	}
 	for tcIndex, tt := range tests {
 		fmt.Println("Num bundles to create: ", tt.numBundlesTxsToCreate)
-		addNumBundlesToSidecar(t, sidecar, tt.numBundlesTxsToCreate, 10, mempool.UnknownPeerID)
+		addNumBundlesToSidecar(t, sidecar, tt.numBundlesTxsToCreate, 10, UnknownPeerID)
 		sidecar.ReapMaxTxs()
 		assert.Equal(t, tt.numBundlesTxsToCreate, sidecar.NumBundles(), "Got %d bundles, expected %d, tc #%d",
 			sidecar.NumBundles(), tt.numBundlesTxsToCreate, tcIndex)
@@ -441,10 +435,7 @@ func TestBasicAddMultipleBundles(t *testing.T) {
 }
 
 func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	// only one since no txs in first
 	{
@@ -453,7 +444,7 @@ func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 			{0, 1, 0, 0},
 			{5, 1, 1, 0},
 		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
 			sidecar.NumBundles(), 1)
 		sidecar.Flush()
@@ -467,7 +458,7 @@ func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 			{5, 5, 1, 0},
 			{5, 10, 1, 0},
 		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
 			sidecar.NumBundles(), 3)
 		sidecar.Flush()
@@ -481,7 +472,7 @@ func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 			{5, 1, 0, 0},
 			{5, 1, 0, 0},
 		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
 			sidecar.NumBundles(), 1)
 		sidecar.Flush()
@@ -495,7 +486,7 @@ func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 			{5, 1, 3, 0},
 			{5, 1, 5, 0},
 		}
-		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
 			sidecar.NumBundles(), 3)
 		sidecar.Flush()
@@ -503,31 +494,51 @@ func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
 }
 
 func TestGetEnforcedBundleSize(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	assert.Equal(t, 0, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 0, sidecar.GetEnforcedBundleSize(0))
 
 	bundles := []testBundleInfo{
 		{5, 1, 0, 0},
 	}
-	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 	assert.Equal(t, 5, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 5, sidecar.GetEnforcedBundleSize(0))
 }
 
 func TestGetCurrBundleSize(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
+	sidecar := NewCListSidecar(0, log.NewNopLogger(), NopMetrics())
 
 	assert.Equal(t, 0, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 0, sidecar.GetCurrBundleSize(0))
 
 	bundles := []testBundleInfo{
 		{5, 1, 0, 0},
 	}
-	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	addBundlesToSidecar(t, sidecar, bundles, UnknownPeerID)
 	assert.Equal(t, 5, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 5, sidecar.GetCurrBundleSize(0))
+}
+
+func abciResponses(n int, code uint32) []*abci.ResponseDeliverTx {
+	responses := make([]*abci.ResponseDeliverTx, 0, n)
+	for i := 0; i < n; i++ {
+		responses = append(responses, &abci.ResponseDeliverTx{Code: code})
+	}
+	return responses
+}
+
+func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
+	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatal("Expected not to fire")
+	case <-timer.C:
+	}
+}
+
+func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
+	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatal("Expected to fire")
+	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	MempoolChannel = byte(0x30)
-
-	SidecarChannel = byte(0x80)
+	MempoolChannel       = byte(0x30)
+	SidecarChannel       = byte(0x50)
+	SidecarLegacyChannel = byte(0x80) // uses the legacy MEVMessage type
 
 	// PeerCatchupSleepIntervalMS defines how much time to sleep if a peer is behind
 	PeerCatchupSleepIntervalMS = 100

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -45,7 +45,7 @@ type Mempool interface {
 	//
 	// If both maxes are negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*MempoolTx) types.Txs
+	ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs
 
 	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
 	// negative, there is no cap on the size of all returned transactions
@@ -112,7 +112,7 @@ type PriorityTxSidecar interface {
 	// ReapMaxTxs reaps up to max transactions from the mempool.
 	// If max is negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxTxs() []*MempoolTx
+	ReapMaxTxs() types.ReapedTxs
 
 	// Lock locks the mempool. The consensus must be able to hold lock to safely update.
 	Lock()
@@ -278,17 +278,6 @@ func (e ErrPreCheck) Error() string {
 // IsPreCheckError returns true if err is due to pre check failure.
 func IsPreCheckError(err error) bool {
 	return errors.As(err, &ErrPreCheck{})
-}
-
-// mempoolTx is a transaction that successfully ran
-type MempoolTx struct { //nolint:revive
-	Height    int64    // height that this tx had been validated in
-	GasWanted int64    // amount of gas this tx states it will require
-	Tx        types.Tx //
-
-	// ids of peers who've sent us this tx (as a map for quick lookups).
-	// senders: PeerID -> bool
-	Senders sync.Map
 }
 
 // MempoolTx is a transaction that successfully ran

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/types"
@@ -12,6 +13,8 @@ import (
 
 const (
 	MempoolChannel = byte(0x30)
+
+	SidecarChannel = byte(0x80)
 
 	// PeerCatchupSleepIntervalMS defines how much time to sleep if a peer is behind
 	PeerCatchupSleepIntervalMS = 100
@@ -42,7 +45,7 @@ type Mempool interface {
 	//
 	// If both maxes are negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs
+	ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*MempoolTx) types.Txs
 
 	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
 	// negative, there is no cap on the size of all returned transactions
@@ -96,6 +99,57 @@ type Mempool interface {
 
 	// SizeBytes returns the total size of all txs in the mempool.
 	SizeBytes() int64
+}
+
+// Sidecar is a dummy version of a mempool only gossipeed through
+// the SidecarChannel with the Sentinel
+type PriorityTxSidecar interface {
+
+	// AddTx takes in a transaction and adds to the sidecar, no checks
+	// given by CheckTx
+	AddTx(tx types.Tx, txInfo TxInfo) error
+
+	// ReapMaxTxs reaps up to max transactions from the mempool.
+	// If max is negative, there is no cap on the size of all returned
+	// transactions (~ all available transactions).
+	ReapMaxTxs() []*MempoolTx
+
+	// Lock locks the mempool. The consensus must be able to hold lock to safely update.
+	Lock()
+
+	// Flush removes all transactions from the mempool and cache
+	Flush()
+
+	// Unlock unlocks the mempool.
+	Unlock()
+
+	// Update informs the sidecar that the given txs were reaped and can be discarded.
+	// NOTE: this should be called *after* block is committed by consensus.
+	// NOTE: Lock/Unlock must be managed by caller
+	Update(
+		blockHeight int64,
+		blockTxs types.Txs,
+		deliverTxResponses []*abci.ResponseDeliverTx,
+	) error
+
+	// TxsAvailable returns a channel which fires once for every height,
+	// and only when transactions are available in the mempool.
+	// NOTE: the returned channel may be nil if EnableTxsAvailable was not called.
+	TxsAvailable() <-chan struct{}
+
+	HeightForFiringAuction() int64
+
+	// EnableTxsAvailable initializes the TxsAvailable channel, ensuring it will
+	// trigger once every height when transactions are available.
+
+	// Size returns the number of transactions in the mempool.
+	Size() int
+
+	// TxsBytes returns the total size of all txs in the mempool.
+	TxsBytes() int64
+
+	// Gets the height of the last received bundle tx. For status rpc purposes.
+	GetLastBundleHeight() int64
 }
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects
@@ -159,6 +213,40 @@ func (e ErrTxTooLarge) Error() string {
 	return fmt.Sprintf("Tx too large. Max size is %d, but got %d", e.Max, e.Actual)
 }
 
+// ErrTxMalformedForBundle is a general malformed error for specific cases
+type ErrTxMalformedForBundle struct {
+	BundleID     int64
+	BundleSize   int64
+	BundleHeight int64
+	BundleOrder  int64
+}
+
+func (e ErrTxMalformedForBundle) Error() string {
+	return fmt.Sprintf(`Tx submitted but malformed with respect to bundling, for bundleID %d, at height %d,
+		with bundleSize %d, and bundleOrder %d`, e.BundleID, e.BundleHeight, e.BundleSize, e.BundleOrder)
+}
+
+// ErrBundleFull means the tx is trying to enter a bundle that has already reached its limit
+type ErrBundleFull struct {
+	BundleID     int64
+	BundleHeight int64
+}
+
+func (e ErrBundleFull) Error() string {
+	return fmt.Sprintf("Tx submitted but bundle is full, for bundleID %d with bundle size %d", e.BundleID, e.BundleHeight)
+}
+
+// ErrWrongHeight means the tx is asking to be in a height that doesn't match the current auction
+type ErrWrongHeight struct {
+	DesiredHeight        int
+	CurrentAuctionHeight int
+}
+
+func (e ErrWrongHeight) Error() string {
+	return fmt.Sprintf("Tx submitted for wrong height, asked for %d, but current auction height is %d",
+		e.DesiredHeight, e.CurrentAuctionHeight)
+}
+
 // ErrMempoolIsFull defines an error where Tendermint and the application cannot
 // handle that much load.
 type ErrMempoolIsFull struct {
@@ -190,4 +278,41 @@ func (e ErrPreCheck) Error() string {
 // IsPreCheckError returns true if err is due to pre check failure.
 func IsPreCheckError(err error) bool {
 	return errors.As(err, &ErrPreCheck{})
+}
+
+// mempoolTx is a transaction that successfully ran
+type MempoolTx struct { //nolint:revive
+	Height    int64    // height that this tx had been validated in
+	GasWanted int64    // amount of gas this tx states it will require
+	Tx        types.Tx //
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	Senders sync.Map
+}
+
+// MempoolTx is a transaction that successfully ran
+type SidecarTx struct {
+	DesiredHeight int64 // height that this tx wants to be included in
+	BundleID      int64 // ordered id of bundle
+	BundleOrder   int64 // order of tx within bundle
+	BundleSize    int64 // total size of bundle
+
+	GasWanted int64    // amount of gas this tx states it will require
+	Tx        types.Tx // tx bytes
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	Senders sync.Map
+}
+
+// Bundle stores information about a sidecar bundle
+type Bundle struct {
+	DesiredHeight int64 // height that this bundle wants to be included in
+	BundleID      int64 // ordered id of bundle
+	CurrSize      int64 // total size of bundle
+	EnforcedSize  int64 // total size of bundle
+
+	GasWanted     int64     // amount of gas this tx states it will require
+	OrderedTxsMap *sync.Map // map from bundleOrder to *mempoolTx
 }

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -10,7 +10,8 @@ import (
 const (
 	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
 	// package.
-	MetricsSubsystem = "mempool"
+	MetricsSubsystem        = "mempool"
+	SidecarMetricsSubsystem = "sidecar"
 )
 
 // Metrics contains metrics exposed by this package.
@@ -39,6 +40,23 @@ type Metrics struct {
 
 	// Number of times transactions are rechecked in the mempool.
 	RecheckTimes metrics.Counter
+
+	// SIDECAR METRICS
+
+	// Histogram of sidecar transaction sizes, in bytes.
+	SidecarTxSizeBytes metrics.Histogram
+	// Size of the sidecar.
+	SidecarSize metrics.Gauge
+
+	// Number of MEV bundles received by the sidecar in total.
+	NumBundlesTotal metrics.Counter
+	// Number of mev bundles received during the last block.
+	NumBundlesLastBlock metrics.Gauge
+
+	// Number of mev transactions added in total.
+	NumMevTxsTotal metrics.Counter
+	// Number of mev transactions received by sidecar in the last block.
+	NumMevTxsLastBlock metrics.Gauge
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -92,6 +110,46 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "recheck_times",
 			Help:      "Number of times transactions are rechecked in the mempool.",
 		}, labels).With(labelsAndValues...),
+
+		// SIDECAR METRICS
+		SidecarSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "size",
+			Help:      "Size of the sidecar (number of uncommitted transactions).",
+		}, labels).With(labelsAndValues...),
+		SidecarTxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "size_bytes",
+			Help:      "MEV transaction sizes in bytes.",
+		}, labels).With(labelsAndValues...),
+
+		NumBundlesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "num_bundles_total",
+			Help:      "Number of MEV bundles received by the sidecar in total.",
+		}, labels).With(labelsAndValues...),
+		NumBundlesLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "num_bundles_last_block",
+			Help:      "Number of MEV bundles received by the sidecar in the last block.",
+		}, labels).With(labelsAndValues...),
+
+		NumMevTxsTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "num_mev_txs_total",
+			Help:      "Number of MEV transactions received to the sidecar in total.",
+		}, labels).With(labelsAndValues...),
+		NumMevTxsLastBlock: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: SidecarMetricsSubsystem,
+			Name:      "num_mev_txs_last_block",
+			Help:      "Number of MEV transactions received to the sidecar in the last block.",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -104,5 +162,15 @@ func NopMetrics() *Metrics {
 		RejectedTxs:  discard.NewCounter(),
 		EvictedTxs:   discard.NewCounter(),
 		RecheckTimes: discard.NewCounter(),
+
+		// SIDECAR METRICS
+		SidecarSize:        discard.NewGauge(),
+		SidecarTxSizeBytes: discard.NewHistogram(),
+
+		NumBundlesTotal:     discard.NewCounter(),
+		NumBundlesLastBlock: discard.NewGauge(),
+
+		NumMevTxsTotal:     discard.NewCounter(),
+		NumMevTxsLastBlock: discard.NewGauge(),
 	}
 }

--- a/mempool/mev_reap.go
+++ b/mempool/mev_reap.go
@@ -1,0 +1,74 @@
+package mempool
+
+import (
+	"fmt"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes, maxGas int64) types.Txs {
+	var (
+		totalGas    int64
+		runningSize int64
+	)
+
+	txs := make([]types.Tx, 0, (len(memplTxs.Txs) + len(sidecarTxs.Txs)))
+	sidecarTxsMap := make(map[types.TxKey]struct{})
+
+	for i, sidecarTx := range sidecarTxs.Txs {
+		fmt.Println("[mev-tendermint]: reaped sidecar mev transaction", getLastNumBytesFromTx(sidecarTx, 20))
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{sidecarTx})
+
+		// Check total size requirement
+		if maxBytes > -1 && runningSize+dataSize > maxBytes {
+			return txs
+		}
+		runningSize += dataSize
+
+		newTotalGas := totalGas + sidecarTxs.GasWanteds[i]
+		if maxGas > -1 && newTotalGas > maxGas {
+			return txs
+		}
+		totalGas = newTotalGas
+		txs = append(txs, sidecarTx)
+		sidecarTxsMap[sidecarTx.Key()] = struct{}{}
+	}
+
+	for i, memplTx := range memplTxs.Txs {
+		if _, ok := sidecarTxsMap[memplTx.Key()]; ok {
+			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
+			fmt.Println("[mev-tendermint]: skipped mempool tx, already found in sidecar", getLastNumBytesFromTx(memplTx, 20))
+			continue
+		}
+
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memplTx})
+
+		// Check total size requirement
+		if maxBytes > -1 && runningSize+dataSize > maxBytes {
+			return txs
+		}
+		runningSize += dataSize
+
+		// Check total gas requirement.
+		// If maxGas is negative, skip this check.
+		// Since newTotalGas < masGas, which
+		// must be non-negative, it follows that this won't overflow.
+		newTotalGas := totalGas + memplTxs.GasWanteds[i]
+		if maxGas > -1 && newTotalGas > maxGas {
+			return txs
+		}
+		totalGas = newTotalGas
+		txs = append(txs, memplTx)
+	}
+	return txs
+}
+
+func getLastNumBytesFromTx(tx types.Tx, numBytes int) string {
+	if len(tx) == 0 {
+		return ""
+	} else if len(tx) < 20 {
+		return tx.String()
+	} else {
+		return tx.String()[len(tx.String())-20:]
+	}
+}

--- a/mempool/mev_reap_test.go
+++ b/mempool/mev_reap_test.go
@@ -1,0 +1,167 @@
+package mempool
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/types"
+)
+
+func TestCombineSidecarAndMempoolTxs_SkipsSidecarTxsInMempoolReap(t *testing.T) {
+	tx := makeTxWithNumBytes(t, 20)
+	// Put one tx in the mempool
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{tx},
+		GasWanteds: []int64{10},
+	}
+	// Put the same tx in sidecarTxs
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{tx},
+		GasWanteds: []int64{10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 50, 500)
+
+	// Assert that it only got reaped once
+	expectedTxs := types.Txs([]types.Tx{tx})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarHassMaxBytes(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 50)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarHasMaxGas(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 20)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_MempoolHasMaxBytes(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	mplTx3 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2, mplTx3},
+		GasWanteds: []int64{10, 10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{},
+		GasWanteds: []int64{},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 40)
+
+	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_MempoolHasMaxGas(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	mplTx3 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2, mplTx3},
+		GasWanteds: []int64{10, 10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{},
+		GasWanteds: []int64{},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 20)
+
+	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_CombinedHasMaxBytes(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2},
+		GasWanteds: []int64{10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 60)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_CombinedHasMaxGas(t *testing.T) {
+	mplTx1 := makeTxWithNumBytes(t, 18)
+	mplTx2 := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx1, mplTx2},
+		GasWanteds: []int64{10, 10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 30)
+
+	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func makeTxWithNumBytes(t *testing.T, numBytes int) types.Tx {
+	tx := make([]byte, numBytes)
+	_, err := rand.Read(tx)
+	if err != nil {
+		t.Error(err)
+	}
+	return tx
+}

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -18,9 +18,9 @@ func (Mempool) Size() int { return 0 }
 func (Mempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempool.TxInfo) error {
 	return nil
 }
-func (Mempool) RemoveTxByKey(txKey types.TxKey) error   { return nil }
-func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (Mempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
+func (Mempool) RemoveTxByKey(txKey types.TxKey) error                           { return nil }
+func (Mempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempool.MempoolTx) types.Txs { return types.Txs{} }
+func (Mempool) ReapMaxTxs(n int) types.Txs                                      { return types.Txs{} }
 func (Mempool) Update(
 	_ int64,
 	_ types.Txs,
@@ -41,3 +41,37 @@ func (Mempool) TxsWaitChan() <-chan struct{} { return nil }
 
 func (Mempool) InitWAL() error { return nil }
 func (Mempool) CloseWAL()      {}
+
+// PriorityTxSidecar is an empty implementation of a PriorityTxSidecar, useful for testing.
+type PriorityTxSidecar struct{}
+
+var _ mempool.PriorityTxSidecar = PriorityTxSidecar{}
+
+func (PriorityTxSidecar) AddTx(_ types.Tx, _ mempool.TxInfo) error { return nil }
+func (PriorityTxSidecar) ReapMaxTxs() []*mempool.MempoolTx         { return []*mempool.MempoolTx{} }
+
+func (PriorityTxSidecar) Lock()   {}
+func (PriorityTxSidecar) Unlock() {}
+
+func (PriorityTxSidecar) HeightForFiringAuction() int64 { return 0 }
+
+func (PriorityTxSidecar) Flush() {}
+func (PriorityTxSidecar) Update(
+	blockHeight int64,
+	blockTxs types.Txs,
+	_ []*abci.ResponseDeliverTx,
+) error {
+	return nil
+}
+
+func (PriorityTxSidecar) TxsAvailable() <-chan struct{} { return make(chan struct{}) }
+func (PriorityTxSidecar) EnableTxsAvailable()           {}
+
+func (PriorityTxSidecar) TxsWaitChan() <-chan struct{} { return nil }
+
+func (PriorityTxSidecar) TargetValidator() []byte { return []byte{} }
+
+func (PriorityTxSidecar) Size() int       { return 0 }
+func (PriorityTxSidecar) TxsBytes() int64 { return 0 }
+
+func (PriorityTxSidecar) GetLastBundleHeight() int64 { return 0 }

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -18,9 +18,9 @@ func (Mempool) Size() int { return 0 }
 func (Mempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempool.TxInfo) error {
 	return nil
 }
-func (Mempool) RemoveTxByKey(txKey types.TxKey) error                           { return nil }
-func (Mempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempool.MempoolTx) types.Txs { return types.Txs{} }
-func (Mempool) ReapMaxTxs(n int) types.Txs                                      { return types.Txs{} }
+func (Mempool) RemoveTxByKey(txKey types.TxKey) error         { return nil }
+func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs { return types.ReapedTxs{} }
+func (Mempool) ReapMaxTxs(n int) types.Txs                    { return types.Txs{} }
 func (Mempool) Update(
 	_ int64,
 	_ types.Txs,
@@ -48,7 +48,7 @@ type PriorityTxSidecar struct{}
 var _ mempool.PriorityTxSidecar = PriorityTxSidecar{}
 
 func (PriorityTxSidecar) AddTx(_ types.Tx, _ mempool.TxInfo) error { return nil }
-func (PriorityTxSidecar) ReapMaxTxs() []*mempool.MempoolTx         { return []*mempool.MempoolTx{} }
+func (PriorityTxSidecar) ReapMaxTxs() types.ReapedTxs              { return types.ReapedTxs{} }
 
 func (PriorityTxSidecar) Lock()   {}
 func (PriorityTxSidecar) Unlock() {}

--- a/mempool/tx.go
+++ b/mempool/tx.go
@@ -14,4 +14,16 @@ type TxInfo struct {
 
 	// SenderP2PID is the actual p2p.ID of the sender, used e.g. for logging.
 	SenderP2PID p2p.ID
+
+	// ordering for sidecar tx
+	BundleID int64
+
+	// auction height desired for tx
+	DesiredHeight int64
+
+	// order desired within bundle (i.e. per BundleID)
+	BundleOrder int64
+
+	// total size of bundle
+	BundleSize int64
 }

--- a/mempool/v0/bench_test.go
+++ b/mempool/v0/bench_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkReap(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000
@@ -28,14 +28,14 @@ func BenchmarkReap(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mp.ReapMaxBytesMaxGas(100000000, 10000000)
+		mp.ReapMaxBytesMaxGas(100000000, 10000000, nil)
 	}
 }
 
 func BenchmarkCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000
@@ -57,7 +57,7 @@ func BenchmarkCheckTx(b *testing.B) {
 func BenchmarkParallelCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000000
@@ -82,7 +82,7 @@ func BenchmarkParallelCheckTx(b *testing.B) {
 func BenchmarkCheckDuplicateTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000

--- a/mempool/v0/bench_test.go
+++ b/mempool/v0/bench_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkReap(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000
@@ -28,14 +28,14 @@ func BenchmarkReap(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mp.ReapMaxBytesMaxGas(100000000, 10000000, nil)
+		mp.ReapMaxBytesMaxGas(100000000, 10000000)
 	}
 }
 
 func BenchmarkCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000
@@ -57,7 +57,7 @@ func BenchmarkCheckTx(b *testing.B) {
 func BenchmarkParallelCheckTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 100000000
@@ -82,7 +82,7 @@ func BenchmarkParallelCheckTx(b *testing.B) {
 func BenchmarkCheckDuplicateTx(b *testing.B) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	mp.config.Size = 1000000

--- a/mempool/v0/cache_test.go
+++ b/mempool/v0/cache_test.go
@@ -16,7 +16,7 @@ import (
 func TestCacheAfterUpdate(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, cleanup := newMempoolWithApp(cc)
+	mp, _, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// reAddIndices & txsInCache can have elements > numTxsToCreate

--- a/mempool/v0/cache_test.go
+++ b/mempool/v0/cache_test.go
@@ -16,7 +16,7 @@ import (
 func TestCacheAfterUpdate(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// reAddIndices & txsInCache can have elements > numTxsToCreate

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -242,8 +242,8 @@ func (mem *CListMempool) CheckTx(
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(tx.Key()); ok {
-			memTx := e.(*clist.CElement).Value.(*mempoolTx)
-			memTx.senders.LoadOrStore(txInfo.SenderID, true)
+			memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
+			memTx.Senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
@@ -313,11 +313,11 @@ func (mem *CListMempool) reqResCb(
 
 // Called from:
 //   - resCbFirstTime (lock not held) if tx is valid
-func (mem *CListMempool) addTx(memTx *mempoolTx) {
+func (mem *CListMempool) addTx(memTx *mempool.MempoolTx) {
 	e := mem.txs.PushBack(memTx)
-	mem.txsMap.Store(memTx.tx.Key(), e)
-	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.tx)))
-	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.tx)))
+	mem.txsMap.Store(memTx.Tx.Key(), e)
+	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.Tx)))
+	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.Tx)))
 }
 
 // Called from:
@@ -337,9 +337,9 @@ func (mem *CListMempool) removeTx(tx types.Tx, elem *clist.CElement, removeFromC
 // RemoveTxByKey removes a transaction from the mempool by its TxKey index.
 func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 	if e, ok := mem.txsMap.Load(txKey); ok {
-		memTx := e.(*clist.CElement).Value.(*mempoolTx)
+		memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
 		if memTx != nil {
-			mem.removeTx(memTx.tx, e.(*clist.CElement), false)
+			mem.removeTx(memTx.Tx, e.(*clist.CElement), false)
 			return nil
 		}
 		return errors.New("transaction not found")
@@ -391,18 +391,18 @@ func (mem *CListMempool) resCbFirstTime(
 				return
 			}
 
-			memTx := &mempoolTx{
-				height:    mem.height,
-				gasWanted: r.CheckTx.GasWanted,
-				tx:        tx,
+			memTx := &mempool.MempoolTx{
+				Height:    mem.height,
+				GasWanted: r.CheckTx.GasWanted,
+				Tx:        tx,
 			}
-			memTx.senders.Store(peerID, true)
+			memTx.Senders.Store(peerID, true)
 			mem.addTx(memTx)
 			mem.logger.Debug(
 				"added good transaction",
 				"tx", types.Tx(tx).Hash(),
 				"res", r,
-				"height", memTx.height,
+				"height", memTx.Height,
 				"total", mem.Size(),
 			)
 			mem.notifyTxsAvailable()
@@ -436,12 +436,12 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 	switch r := res.Value.(type) {
 	case *abci.Response_CheckTx:
 		tx := req.GetCheckTx().Tx
-		memTx := mem.recheckCursor.Value.(*mempoolTx)
+		memTx := mem.recheckCursor.Value.(*mempool.MempoolTx)
 
 		// Search through the remaining list of tx to recheck for a transaction that matches
 		// the one we received from the ABCI application.
 		for {
-			if bytes.Equal(tx, memTx.tx) {
+			if bytes.Equal(tx, memTx.Tx) {
 				// We've found a tx in the recheck list that matches the tx that we
 				// received from the ABCI application.
 				// Break, and use this transaction for further checks.
@@ -451,7 +451,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			mem.logger.Error(
 				"re-CheckTx transaction mismatch",
 				"got", types.Tx(tx),
-				"expected", memTx.tx,
+				"expected", memTx.Tx,
 			)
 
 			if mem.recheckCursor == mem.recheckEnd {
@@ -463,7 +463,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			}
 
 			mem.recheckCursor = mem.recheckCursor.Next()
-			memTx = mem.recheckCursor.Value.(*mempoolTx)
+			memTx = mem.recheckCursor.Value.(*mempool.MempoolTx)
 		}
 
 		var postCheckErr error
@@ -518,7 +518,7 @@ func (mem *CListMempool) notifyTxsAvailable() {
 }
 
 // Safe for concurrent use by multiple goroutines.
-func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
+func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*mempool.MempoolTx) types.Txs {
 	mem.updateMtx.RLock()
 	defer mem.updateMtx.RUnlock()
 
@@ -527,16 +527,47 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 		runningSize int64
 	)
 
-	// TODO: we will get a performance boost if we have a good estimate of avg
-	// size per tx, and set the initial capacity based off of that.
-	// txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max/mem.avgTxSize))
-	txs := make([]types.Tx, 0, mem.txs.Len())
+	txs := make([]types.Tx, 0, (mem.txs.Len() + len(sidecarTxs)))
+	var sidecarTxsMap sync.Map
+
+	for _, scMemTx := range sidecarTxs {
+		mem.logger.Debug(
+			"reaped sidecar mev transaction",
+			"tx", scMemTx.Tx.Hash(),
+			"height", scMemTx.Height,
+		)
+		dataSize := types.ComputeProtoSizeForTxs(append(txs, scMemTx.Tx))
+
+		// Check total size requirement
+		if maxBytes > -1 && dataSize > maxBytes {
+			return txs
+		}
+
+		newTotalGas := totalGas + scMemTx.GasWanted
+		if maxGas > -1 && newTotalGas > maxGas {
+			return txs
+		}
+		totalGas = newTotalGas
+		txs = append(txs, scMemTx.Tx)
+		sidecarTxsMap.Store(scMemTx.Tx.Key(), true)
+	}
+
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempoolTx)
+		memTx := e.Value.(*mempool.MempoolTx)
 
-		txs = append(txs, memTx.tx)
+		if _, ok := sidecarTxsMap.Load(memTx.Tx.Key()); ok {
+			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
+			mem.logger.Debug(
+				"skipped mempool tx, already found in sidecar",
+				"tx", memTx.Tx.Hash(),
+				"height", memTx.Height,
+			)
+			continue
+		}
 
-		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.tx})
+		txs = append(txs, memTx.Tx)
+
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.Tx})
 
 		// Check total size requirement
 		if maxBytes > -1 && runningSize+dataSize > maxBytes {
@@ -549,7 +580,7 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 		// If maxGas is negative, skip this check.
 		// Since newTotalGas < masGas, which
 		// must be non-negative, it follows that this won't overflow.
-		newTotalGas := totalGas + memTx.gasWanted
+		newTotalGas := totalGas + memTx.GasWanted
 		if maxGas > -1 && newTotalGas > maxGas {
 			return txs[:len(txs)-1]
 		}
@@ -569,8 +600,8 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 
 	txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max))
 	for e := mem.txs.Front(); e != nil && len(txs) <= max; e = e.Next() {
-		memTx := e.Value.(*mempoolTx)
-		txs = append(txs, memTx.tx)
+		memTx := e.Value.(*mempool.MempoolTx)
+		txs = append(txs, memTx.Tx)
 	}
 	return txs
 }
@@ -649,9 +680,9 @@ func (mem *CListMempool) recheckTxs() {
 	// Push txs to proxyAppConn
 	// NOTE: globalCb may be called concurrently.
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempoolTx)
+		memTx := e.Value.(*mempool.MempoolTx)
 		mem.proxyAppConn.CheckTxAsync(abci.RequestCheckTx{
-			Tx:   memTx.tx,
+			Tx:   memTx.Tx,
 			Type: abci.CheckTxType_Recheck,
 		})
 	}
@@ -660,19 +691,3 @@ func (mem *CListMempool) recheckTxs() {
 }
 
 //--------------------------------------------------------------------------------
-
-// mempoolTx is a transaction that successfully ran
-type mempoolTx struct {
-	height    int64    // height that this tx had been validated in
-	gasWanted int64    // amount of gas this tx states it will require
-	tx        types.Tx //
-
-	// ids of peers who've sent us this tx (as a map for quick lookups).
-	// senders: PeerID -> bool
-	senders sync.Map
-}
-
-// Height returns the height for this transaction
-func (memTx *mempoolTx) Height() int64 {
-	return atomic.LoadInt64(&memTx.height)
-}

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -242,8 +242,8 @@ func (mem *CListMempool) CheckTx(
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(tx.Key()); ok {
-			memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
-			memTx.Senders.LoadOrStore(txInfo.SenderID, true)
+			memTx := e.(*clist.CElement).Value.(*mempoolTx)
+			memTx.senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
@@ -313,11 +313,11 @@ func (mem *CListMempool) reqResCb(
 
 // Called from:
 //   - resCbFirstTime (lock not held) if tx is valid
-func (mem *CListMempool) addTx(memTx *mempool.MempoolTx) {
+func (mem *CListMempool) addTx(memTx *mempoolTx) {
 	e := mem.txs.PushBack(memTx)
-	mem.txsMap.Store(memTx.Tx.Key(), e)
-	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.Tx)))
-	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.Tx)))
+	mem.txsMap.Store(memTx.tx.Key(), e)
+	atomic.AddInt64(&mem.txsBytes, int64(len(memTx.tx)))
+	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.tx)))
 }
 
 // Called from:
@@ -337,9 +337,9 @@ func (mem *CListMempool) removeTx(tx types.Tx, elem *clist.CElement, removeFromC
 // RemoveTxByKey removes a transaction from the mempool by its TxKey index.
 func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 	if e, ok := mem.txsMap.Load(txKey); ok {
-		memTx := e.(*clist.CElement).Value.(*mempool.MempoolTx)
+		memTx := e.(*clist.CElement).Value.(*mempoolTx)
 		if memTx != nil {
-			mem.removeTx(memTx.Tx, e.(*clist.CElement), false)
+			mem.removeTx(memTx.tx, e.(*clist.CElement), false)
 			return nil
 		}
 		return errors.New("transaction not found")
@@ -391,18 +391,18 @@ func (mem *CListMempool) resCbFirstTime(
 				return
 			}
 
-			memTx := &mempool.MempoolTx{
-				Height:    mem.height,
-				GasWanted: r.CheckTx.GasWanted,
-				Tx:        tx,
+			memTx := &mempoolTx{
+				height:    mem.height,
+				gasWanted: r.CheckTx.GasWanted,
+				tx:        tx,
 			}
-			memTx.Senders.Store(peerID, true)
+			memTx.senders.Store(peerID, true)
 			mem.addTx(memTx)
 			mem.logger.Debug(
 				"added good transaction",
 				"tx", types.Tx(tx).Hash(),
 				"res", r,
-				"height", memTx.Height,
+				"height", memTx.height,
 				"total", mem.Size(),
 			)
 			mem.notifyTxsAvailable()
@@ -436,12 +436,12 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 	switch r := res.Value.(type) {
 	case *abci.Response_CheckTx:
 		tx := req.GetCheckTx().Tx
-		memTx := mem.recheckCursor.Value.(*mempool.MempoolTx)
+		memTx := mem.recheckCursor.Value.(*mempoolTx)
 
 		// Search through the remaining list of tx to recheck for a transaction that matches
 		// the one we received from the ABCI application.
 		for {
-			if bytes.Equal(tx, memTx.Tx) {
+			if bytes.Equal(tx, memTx.tx) {
 				// We've found a tx in the recheck list that matches the tx that we
 				// received from the ABCI application.
 				// Break, and use this transaction for further checks.
@@ -451,7 +451,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			mem.logger.Error(
 				"re-CheckTx transaction mismatch",
 				"got", types.Tx(tx),
-				"expected", memTx.Tx,
+				"expected", memTx.tx,
 			)
 
 			if mem.recheckCursor == mem.recheckEnd {
@@ -463,7 +463,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			}
 
 			mem.recheckCursor = mem.recheckCursor.Next()
-			memTx = mem.recheckCursor.Value.(*mempool.MempoolTx)
+			memTx = mem.recheckCursor.Value.(*mempoolTx)
 		}
 
 		var postCheckErr error
@@ -518,7 +518,7 @@ func (mem *CListMempool) notifyTxsAvailable() {
 }
 
 // Safe for concurrent use by multiple goroutines.
-func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs []*mempool.MempoolTx) types.Txs {
+func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs {
 	mem.updateMtx.RLock()
 	defer mem.updateMtx.RUnlock()
 
@@ -527,51 +527,25 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 		runningSize int64
 	)
 
-	txs := make([]types.Tx, 0, (mem.txs.Len() + len(sidecarTxs)))
-	var sidecarTxsMap sync.Map
-
-	for _, scMemTx := range sidecarTxs {
-		mem.logger.Debug(
-			"reaped sidecar mev transaction",
-			"tx", scMemTx.Tx.Hash(),
-			"height", scMemTx.Height,
-		)
-		dataSize := types.ComputeProtoSizeForTxs(append(txs, scMemTx.Tx))
-
-		// Check total size requirement
-		if maxBytes > -1 && dataSize > maxBytes {
-			return txs
-		}
-
-		newTotalGas := totalGas + scMemTx.GasWanted
-		if maxGas > -1 && newTotalGas > maxGas {
-			return txs
-		}
-		totalGas = newTotalGas
-		txs = append(txs, scMemTx.Tx)
-		sidecarTxsMap.Store(scMemTx.Tx.Key(), true)
-	}
-
+	// TODO: we will get a performance boost if we have a good estimate of avg
+	// size per tx, and set the initial capacity based off of that.
+	// txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max/mem.avgTxSize))
+	txs := make([]types.Tx, 0, mem.txs.Len())
+	gasWanteds := make([]int64, 0, mem.txs.Len())
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
+		memTx := e.Value.(*mempoolTx)
 
-		if _, ok := sidecarTxsMap.Load(memTx.Tx.Key()); ok {
-			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
-			mem.logger.Debug(
-				"skipped mempool tx, already found in sidecar",
-				"tx", memTx.Tx.Hash(),
-				"height", memTx.Height,
-			)
-			continue
-		}
+		txs = append(txs, memTx.tx)
+		gasWanteds = append(gasWanteds, memTx.gasWanted)
 
-		txs = append(txs, memTx.Tx)
-
-		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.Tx})
+		dataSize := types.ComputeProtoSizeForTxs([]types.Tx{memTx.tx})
 
 		// Check total size requirement
 		if maxBytes > -1 && runningSize+dataSize > maxBytes {
-			return txs[:len(txs)-1]
+			return types.ReapedTxs{
+				Txs:        txs[:len(txs)-1],
+				GasWanteds: gasWanteds[:len(txs)-1],
+			}
 		}
 
 		runningSize += dataSize
@@ -580,13 +554,19 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, sidecarTxs [
 		// If maxGas is negative, skip this check.
 		// Since newTotalGas < masGas, which
 		// must be non-negative, it follows that this won't overflow.
-		newTotalGas := totalGas + memTx.GasWanted
+		newTotalGas := totalGas + memTx.gasWanted
 		if maxGas > -1 && newTotalGas > maxGas {
-			return txs[:len(txs)-1]
+			return types.ReapedTxs{
+				Txs:        txs[:len(txs)-1],
+				GasWanteds: gasWanteds[:len(txs)-1],
+			}
 		}
 		totalGas = newTotalGas
 	}
-	return txs
+	return types.ReapedTxs{
+		Txs:        txs,
+		GasWanteds: gasWanteds,
+	}
 }
 
 // Safe for concurrent use by multiple goroutines.
@@ -600,8 +580,8 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 
 	txs := make([]types.Tx, 0, tmmath.MinInt(mem.txs.Len(), max))
 	for e := mem.txs.Front(); e != nil && len(txs) <= max; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
-		txs = append(txs, memTx.Tx)
+		memTx := e.Value.(*mempoolTx)
+		txs = append(txs, memTx.tx)
 	}
 	return txs
 }
@@ -680,9 +660,9 @@ func (mem *CListMempool) recheckTxs() {
 	// Push txs to proxyAppConn
 	// NOTE: globalCb may be called concurrently.
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		memTx := e.Value.(*mempool.MempoolTx)
+		memTx := e.Value.(*mempoolTx)
 		mem.proxyAppConn.CheckTxAsync(abci.RequestCheckTx{
-			Tx:   memTx.Tx,
+			Tx:   memTx.tx,
 			Type: abci.CheckTxType_Recheck,
 		})
 	}
@@ -691,3 +671,19 @@ func (mem *CListMempool) recheckTxs() {
 }
 
 //--------------------------------------------------------------------------------
+
+// mempoolTx is a transaction that successfully ran
+type mempoolTx struct {
+	height    int64    // height that this tx had been validated in
+	gasWanted int64    // amount of gas this tx states it will require
+	tx        types.Tx //
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	senders sync.Map
+}
+
+// Height returns the height for this transaction
+func (memTx *mempoolTx) Height() int64 {
+	return atomic.LoadInt64(&memTx.height)
+}

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -34,17 +33,6 @@ import (
 // test.
 type cleanupFunc func()
 
-type testBundleInfo struct {
-	BundleSize    int64
-	DesiredHeight int64
-	BundleID      int64
-	PeerID        uint16
-}
-
-var (
-	ZeroedTxInfoForSidecar = mempool.TxInfo{DesiredHeight: 1, BundleID: 0, BundleOrder: 0, BundleSize: 1}
-)
-
 func newMempoolWithAppMock(cc proxy.ClientCreator, client abciclient.Client) (*CListMempool, cleanupFunc, error) {
 	conf := config.ResetTestRoot("mempool_test")
 
@@ -68,14 +56,14 @@ func newMempoolWithAppAndConfigMock(cc proxy.ClientCreator,
 	return mp, func() { os.RemoveAll(cfg.RootDir) }
 }
 
-func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, *CListPriorityTxSidecar, cleanupFunc) {
+func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, cleanupFunc) {
 	conf := config.ResetTestRoot("mempool_test")
 
-	mp, sc, cu := newMempoolWithAppAndConfig(cc, conf)
-	return mp, sc, cu
+	mp, cu := newMempoolWithAppAndConfig(cc, conf)
+	return mp, cu
 }
 
-func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CListMempool, *CListPriorityTxSidecar, cleanupFunc) {
+func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CListMempool, cleanupFunc) {
 	appConnMem, _ := cc.NewABCIClient()
 	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	err := appConnMem.Start()
@@ -85,9 +73,8 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CL
 
 	mp := NewCListMempool(cfg.Mempool, appConnMem, 0)
 	mp.SetLogger(log.TestingLogger())
-	sidecar := NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 
-	return mp, sidecar, func() { os.RemoveAll(cfg.RootDir) }
+	return mp, func() { os.RemoveAll(cfg.RootDir) }
 }
 
 func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
@@ -108,7 +95,7 @@ func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
 	}
 }
 
-func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sidecar mempool.PriorityTxSidecar, addToSidecar bool) types.Txs {
+func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16) types.Txs {
 	txs := make(types.Txs, count)
 	txInfo := mempool.TxInfo{SenderID: peerID}
 	for i := 0; i < count; i++ {
@@ -127,11 +114,6 @@ func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sideca
 			}
 			t.Fatalf("CheckTx failed: %v while checking #%d tx", err, i)
 		}
-		if addToSidecar {
-			if err := sidecar.AddTx(txBytes, txInfo); err != nil {
-				t.Error(err)
-			}
-		}
 	}
 	return txs
 }
@@ -139,17 +121,17 @@ func checkTxs(t *testing.T, mp mempool.Mempool, count int, peerID uint16, sideca
 func TestReapMaxBytesMaxGas(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// Ensure gas calculation behaves as expected
-	checkTxs(t, mp, 1, mempool.UnknownPeerID, nil, false)
-	tx0 := mp.TxsFront().Value.(*mempool.MempoolTx)
+	checkTxs(t, mp, 1, mempool.UnknownPeerID)
+	tx0 := mp.TxsFront().Value.(*mempoolTx)
 	// assert that kv store has gas wanted = 1.
-	require.Equal(t, app.CheckTx(abci.RequestCheckTx{Tx: tx0.Tx}).GasWanted, int64(1), "KVStore had a gas value neq to 1")
-	require.Equal(t, tx0.GasWanted, int64(1), "transactions gas was set incorrectly")
+	require.Equal(t, app.CheckTx(abci.RequestCheckTx{Tx: tx0.tx}).GasWanted, int64(1), "KVStore had a gas value neq to 1")
+	require.Equal(t, tx0.gasWanted, int64(1), "transactions gas was set incorrectly")
 	// ensure each tx is 20 bytes long
-	require.Equal(t, len(tx0.Tx), 20, "Tx is longer than 20 bytes")
+	require.Equal(t, len(tx0.tx), 20, "Tx is longer than 20 bytes")
 	mp.Flush()
 
 	// each table driven test creates numTxsToCreate txs with checkTx, and at the end clears all remaining txs.
@@ -177,67 +159,18 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 		{20, 20000, 30, 20},
 	}
 	for tcIndex, tt := range tests {
-		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID, nil, false)
-		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas, nil)
+		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID)
+		got := mp.ReapMaxBytesMaxGas(tt.maxBytes, tt.maxGas).Txs
 		assert.Equal(t, tt.expectedNumTxs, len(got), "Got %d txs, expected %d, tc #%d",
 			len(got), tt.expectedNumTxs, tcIndex)
 		mp.Flush()
 	}
 }
 
-func TestReapMaxBytesMaxGas_ReapsSidecar(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// Make sidecar txes consisting of one tx
-	tx := tmrand.Bytes(20)
-	expectedTxs := make(types.Txs, 1)
-	expectedTxs[0] = tx
-	sidecarTxs := []*mempool.MempoolTx{
-		{
-			Height:    5,
-			GasWanted: 100,
-			Tx:        tx,
-		},
-	}
-
-	// Pass sidecar txes to reap
-	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
-
-	// Assert that it got reaped
-	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
-}
-
-func TestReapMaxBytesMaxGas_SkipsSidecarTxsInMempoolReap(t *testing.T) {
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	// Put one tx in the mempool
-	expectedTxs := checkTxs(t, mp, 1, mempool.UnknownPeerID, nil, false)
-	// Put the same tx in sidecarTxs
-	sidecarTxs := []*mempool.MempoolTx{
-		{
-			Height:    5,
-			GasWanted: 100,
-			Tx:        expectedTxs[0],
-		},
-	}
-
-	// Reap
-	reapedTxs := mp.ReapMaxBytesMaxGas(50, 500, sidecarTxs)
-
-	// Assert that it only got reaped once
-	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
-}
-
 func TestMempoolFilters(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 	emptyTxArr := []types.Tx{[]byte{}}
 
@@ -267,7 +200,7 @@ func TestMempoolFilters(t *testing.T) {
 	for tcIndex, tt := range tests {
 		err := mp.Update(1, emptyTxArr, abciResponses(len(emptyTxArr), abci.CodeTypeOK), tt.preFilter, tt.postFilter)
 		require.NoError(t, err)
-		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID, nil, false)
+		checkTxs(t, mp, tt.numTxsToCreate, mempool.UnknownPeerID)
 		require.Equal(t, tt.expectedNumTxs, mp.Size(), "mempool had the incorrect size, on test case %d", tcIndex)
 		mp.Flush()
 	}
@@ -276,7 +209,7 @@ func TestMempoolFilters(t *testing.T) {
 func TestMempoolUpdate(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	// 1. Adds valid txs to the cache
@@ -366,7 +299,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 	cc := proxy.NewLocalClientCreator(app)
 	wcfg := config.DefaultConfig()
 	wcfg.Mempool.KeepInvalidTxsInCache = true
-	mp, _, cleanup := newMempoolWithAppAndConfig(cc, wcfg)
+	mp, cleanup := newMempoolWithAppAndConfig(cc, wcfg)
 	defer cleanup()
 
 	// 1. An invalid transaction must remain in the cache after Update
@@ -416,7 +349,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 func TestTxsAvailable(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 	mp.EnableTxsAvailable()
 
@@ -426,7 +359,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch of txs, it should only fire once
-	txs := checkTxs(t, mp, 100, mempool.UnknownPeerID, nil, false)
+	txs := checkTxs(t, mp, 100, mempool.UnknownPeerID)
 	ensureFire(t, mp.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
@@ -441,7 +374,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch more txs. we already fired for this height so it shouldnt fire again
-	moreTxs := checkTxs(t, mp, 50, mempool.UnknownPeerID, nil, false)
+	moreTxs := checkTxs(t, mp, 50, mempool.UnknownPeerID)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// now call update with all the txs. it should not fire as there are no txs left
@@ -452,7 +385,7 @@ func TestTxsAvailable(t *testing.T) {
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 
 	// send a bunch more txs, it should only fire once
-	checkTxs(t, mp, 100, mempool.UnknownPeerID, nil, false)
+	checkTxs(t, mp, 100, mempool.UnknownPeerID)
 	ensureFire(t, mp.TxsAvailable(), timeoutMS)
 	ensureNoFire(t, mp.TxsAvailable(), timeoutMS)
 }
@@ -461,7 +394,7 @@ func TestSerialReap(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
 
-	mp, _, cleanup := newMempoolWithApp(cc)
+	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	appConnCon, _ := cc.NewABCIClient()
@@ -493,7 +426,7 @@ func TestSerialReap(t *testing.T) {
 	}
 
 	reapCheck := func(exp int) {
-		txs := mp.ReapMaxBytesMaxGas(-1, -1, nil)
+		txs := mp.ReapMaxBytesMaxGas(-1, -1).Txs
 		require.Equal(t, len(txs), exp, fmt.Sprintf("Expected to reap %v txs but got %v", exp, len(txs)))
 	}
 
@@ -567,43 +500,11 @@ func TestSerialReap(t *testing.T) {
 	reapCheck(600)
 }
 
-// multiple go routines constantly try to insert bundles
-// as they get reaped
-func TestMempoolConcurrency(t *testing.T) {
-
-	app := kvstore.NewApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	_, sidecar, cleanup := newMempoolWithApp(cc)
-	defer cleanup()
-
-	var wg sync.WaitGroup
-
-	numProcesses := 15
-	numBundlesToAddPerProcess := 5
-	numTxPerBundle := 10
-	wg.Add(numProcesses)
-
-	for i := 0; i < numProcesses; i++ {
-
-		go func() {
-			defer wg.Done()
-			addNumBundlesToSidecar(t, sidecar, numBundlesToAddPerProcess, int64(numTxPerBundle), mempool.UnknownPeerID)
-		}()
-
-	}
-
-	wg.Wait()
-
-	txs := sidecar.ReapMaxTxs()
-	assert.Equal(t, (numBundlesToAddPerProcess * numTxPerBundle), len(txs), "Got %d txs, expected %d",
-		len(txs), (numBundlesToAddPerProcess * numTxPerBundle))
-}
-
 func TestMempool_CheckTxChecksTxSize(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := proxy.NewLocalClientCreator(app)
 
-	mempl, _, cleanup := newMempoolWithApp(cc)
+	mempl, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
 	maxTxSize := mempl.config.MaxTxBytes
@@ -652,7 +553,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	cfg := config.ResetTestRoot("mempool_test")
 
 	cfg.Mempool.MaxTxsBytes = 10
-	mp, _, cleanup := newMempoolWithAppAndConfig(cc, cfg)
+	mp, cleanup := newMempoolWithAppAndConfig(cc, cfg)
 	defer cleanup()
 
 	// 1. zero by default
@@ -693,7 +594,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	app2 := kvstore.NewApplication()
 	cc = proxy.NewLocalClientCreator(app2)
 
-	mp, _, cleanup = newMempoolWithApp(cc)
+	mp, cleanup = newMempoolWithApp(cc)
 	defer cleanup()
 
 	txBytes := make([]byte, 8)
@@ -753,7 +654,7 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 
 	cfg := config.ResetTestRoot("mempool_test")
 
-	mp, _, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
+	mp, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
 	defer cleanup()
 
 	// generate small number of txs

--- a/mempool/v0/clist_sidecar.go
+++ b/mempool/v0/clist_sidecar.go
@@ -1,0 +1,651 @@
+package v0
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/clist"
+	"github.com/tendermint/tendermint/libs/log"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
+	"github.com/tendermint/tendermint/mempool"
+	"github.com/tendermint/tendermint/types"
+)
+
+// CListPriorityTxSidecar is an ordered in-memory pool for transactions stored
+// on sentry nodes that validators can pull from. Transaction validity is not checked using the
+// CheckTx abci message since no transactions are added to the mempool. The
+// CListPriorityTxSidecar uses a concurrent list structure for storing transactions that can
+// be efficiently accessed by multiple concurrent readers.
+type CListPriorityTxSidecar struct {
+	// Atomic integers
+	height                 int64 // the last block Update()'d to
+	heightForFiringAuction int64 // the height of the block to fire the auction for
+	txsBytes               int64 // total size of sidecar, in bytes
+	lastBundleHeight       int64 // height of last accepted bundle tx, for status rpc purposes
+
+	// notify listeners (ie. consensus) when txs are available
+	notifiedTxsAvailable bool
+	txsAvailable         chan struct{} // fires once for each height, when the mempool is not empty
+
+	txs    *clist.CList // concurrent linked-list of good SidecarTxs
+	txsMap sync.Map
+
+	// sync.Map: Key{height, bundleID} -> Bundle{
+	// // height int64
+	// // enforcedSize int64
+	// // currSize int64
+	// // bundleID int64
+	// // sync.Map bundleOrder -> *SidecarTx
+	// }
+	bundles     sync.Map
+	maxBundleID int64
+
+	updateMtx tmsync.RWMutex
+
+	maxBundleIDMtx sync.Mutex
+	bundleSizeMtx  sync.Mutex
+
+	// Keep a cache of already-seen txs.
+	// This reduces the pressure on the proxyApp.
+	cache mempool.TxCache
+
+	logger log.Logger
+
+	metrics *mempool.Metrics
+}
+
+var _ mempool.PriorityTxSidecar = &CListPriorityTxSidecar{}
+
+type Key struct {
+	height, bundleID int64
+}
+
+// NewCListSidecar returns a new sidecar with the given configuration
+// takes in the logger for the mempool
+func NewCListSidecar(
+	height int64,
+	memLogger log.Logger,
+	memMetrics *mempool.Metrics,
+) *CListPriorityTxSidecar {
+	sidecar := &CListPriorityTxSidecar{
+		txs:                    clist.New(),
+		height:                 height,
+		heightForFiringAuction: height + 1,
+		logger:                 memLogger,
+		metrics:                memMetrics,
+	}
+	sidecar.cache = mempool.NewLRUTxCache(10000)
+	return sidecar
+}
+
+func (sc *CListPriorityTxSidecar) PrettyPrintBundles() {
+	fmt.Println("-------------")
+	for bundleIDIter := 0; bundleIDIter <= int(sc.maxBundleID); bundleIDIter++ {
+		bundleIDIter := int64(bundleIDIter)
+		if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleIDIter}); ok {
+			bundle := bundle.(*mempool.Bundle)
+			fmt.Printf("BUNDLE ID: %d\n", bundleIDIter)
+
+			innerOrderMap := bundle.OrderedTxsMap
+			bundleSize := bundle.CurrSize
+			for bundleOrderIter := 0; bundleOrderIter < int(bundleSize); bundleOrderIter++ {
+				bundleOrderIter := int64(bundleOrderIter)
+
+				if scTx, ok := innerOrderMap.Load(bundleOrderIter); ok {
+					scTx := scTx.(*mempool.SidecarTx)
+					fmt.Printf("---> ORDER %d: %s\n", bundleOrderIter, scTx.Tx)
+				}
+			}
+		}
+	}
+	fmt.Println("-------------")
+}
+
+//--------------------------------------------------------------------------------
+
+// NOTE: not thread safe - should only be called once, on startup
+func (sc *CListPriorityTxSidecar) EnableTxsAvailable() {
+	sc.txsAvailable = make(chan struct{}, 1)
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) TxsAvailable() <-chan struct{} {
+	return sc.txsAvailable
+}
+
+func (sc *CListPriorityTxSidecar) notifyTxsAvailable() {
+	if sc.Size() == 0 {
+		fmt.Println("[mev-tendermint]: ERROR: notified txs available but sidecar is empty!")
+	}
+	if sc.txsAvailable != nil && !sc.notifiedTxsAvailable {
+		// channel cap is 1, so this will send once
+		sc.notifiedTxsAvailable = true
+		select {
+		case sc.txsAvailable <- struct{}{}:
+		default:
+		}
+	}
+}
+
+//--------------------------------------------------------------------------------
+
+func (sc *CListPriorityTxSidecar) AddTx(tx types.Tx, txInfo mempool.TxInfo) error {
+
+	sc.updateMtx.RLock()
+	// use defer to unlock mutex because application (*local client*) might panic
+	defer sc.updateMtx.RUnlock()
+
+	// don't add any txs already in cache
+	if !sc.cache.Push(tx) {
+		sc.logger.Debug(
+			"rejected sidecarTx",
+			"reason", "already in cache",
+			"bundleId", txInfo.BundleID,
+			"bundleOrder", txInfo.BundleOrder,
+			"tx", tx.Hash(),
+		)
+		// Record a new sender for a tx we've already seen.
+		// Note it's possible a tx is still in the cache but no longer in the mempool
+		// (eg. after committing a block, txs are removed from mempool but not cache),
+		// so we only record the sender for txs still in the mempool.
+		// Record a new sender for a tx we've already seen.
+
+		if e, ok := sc.txsMap.Load(tx.Key()); ok {
+			scTx := e.(*clist.CElement).Value.(*mempool.SidecarTx)
+			scTx.Senders.LoadOrStore(txInfo.SenderID, true)
+		}
+
+		return mempool.ErrTxInCache
+	}
+
+	scTx := &mempool.SidecarTx{
+		DesiredHeight: txInfo.DesiredHeight,
+		Tx:            tx,
+		BundleID:      txInfo.BundleID,
+		BundleOrder:   txInfo.BundleOrder,
+		BundleSize:    txInfo.BundleSize,
+	}
+
+	// add to metrics that we've received a new tx
+	sc.metrics.NumMevTxsTotal.Add(1)
+
+	// -------- BASIC CHECKS ON TX INFO ---------
+
+	// Can't add transactions asking to be included in a height for auction we're not on
+	if txInfo.DesiredHeight < sc.heightForFiringAuction {
+		sc.logger.Info(
+			"failed adding sidecarTx",
+			"reason", "trying to add a tx for wrong height",
+			"desiredHeight", txInfo.DesiredHeight,
+			"currAuctionHeight", sc.heightForFiringAuction,
+			"bundleOd", txInfo.BundleID,
+			"bundleOrder", txInfo.BundleOrder,
+			"tx", tx.Hash(),
+		)
+		return mempool.ErrWrongHeight{
+			DesiredHeight:        int(txInfo.DesiredHeight),
+			CurrentAuctionHeight: int(sc.heightForFiringAuction),
+		}
+	}
+
+	// revert if tx asking to be included has an order greater/equal to size
+	if txInfo.BundleOrder >= txInfo.BundleSize {
+		sc.logger.Info(
+			"failed adding sidecarTx",
+			"reason", "trying to insert a tx for bundle at an order greater than the size of the bundle...",
+			"bundleId", txInfo.BundleID,
+			"bundleOrder", txInfo.BundleOrder,
+			"bundleSize", txInfo.BundleSize,
+			"tx", tx.Hash(),
+		)
+		return mempool.ErrTxMalformedForBundle{
+			BundleID:     txInfo.BundleID,
+			BundleSize:   txInfo.BundleSize,
+			BundleHeight: txInfo.DesiredHeight,
+			BundleOrder:  txInfo.BundleOrder,
+		}
+	}
+
+	// -------- BUNDLE EXISTENCE CHECKS ---------
+
+	var bundle *mempool.Bundle
+	// load existing bundle, or MAKE NEW if not
+	existingBundle, _ := sc.bundles.LoadOrStore(Key{txInfo.DesiredHeight, txInfo.BundleID}, &mempool.Bundle{
+		DesiredHeight: txInfo.DesiredHeight,
+		BundleID:      txInfo.BundleID,
+		CurrSize:      int64(0),
+		EnforcedSize:  txInfo.BundleSize,
+		// TODO: add from gossip info?
+		GasWanted:     int64(0),
+		OrderedTxsMap: &sync.Map{},
+	})
+	bundle = existingBundle.(*mempool.Bundle)
+
+	// -------- BUNDLE SIZE CHECKS ---------
+
+	// check if bundle is asking for a different size than one already stored
+	if txInfo.BundleSize != bundle.EnforcedSize {
+		sc.logger.Info(
+			"failed adding sidecarTx",
+			"reason", "trying to insert a tx for bundle at an order greater than the size of the bundle...",
+			"bundle id", txInfo.BundleID,
+			"bundle size", txInfo.BundleSize,
+			"enforced size", bundle.EnforcedSize,
+			"tx", tx.Hash(),
+		)
+		return mempool.ErrTxMalformedForBundle{
+			BundleID:     txInfo.BundleID,
+			BundleSize:   txInfo.BundleSize,
+			BundleHeight: txInfo.DesiredHeight,
+			BundleOrder:  txInfo.BundleOrder,
+		}
+	}
+
+	shouldReturn, err := func() (bool, error) {
+		// TODO: make this a lock per bundle?
+		sc.bundleSizeMtx.Lock()
+		defer sc.bundleSizeMtx.Unlock()
+		// Can't add transactions if the bundle is already full
+		// check if the current size of this bundle is greater than the expected size for the bundle, if so skip
+		if bundle.CurrSize >= bundle.EnforcedSize {
+			sc.logger.Info(
+				"failed adding sidecarTx",
+				"reason", "bundle already full for this BundleID...",
+				"bundle id", txInfo.BundleID,
+				"bundle curr size", bundle.CurrSize,
+				"enforced size", bundle.EnforcedSize,
+				"tx", tx.Hash(),
+			)
+			return false, mempool.ErrBundleFull{
+				BundleID:     txInfo.BundleID,
+				BundleHeight: txInfo.BundleSize,
+			}
+		}
+
+		// -------- TX INSERTION INTO BUNDLE ---------
+
+		// get the map of order -> scTx
+		orderedTxsMap := bundle.OrderedTxsMap
+
+		// if we already have a tx at this BundleID, bundleOrder, and height, then skip this one!
+		if _, loaded := orderedTxsMap.LoadOrStore(txInfo.BundleOrder, scTx); loaded {
+			// if we had the tx already, then skip
+			sc.logger.Info(
+				"failed adding sidecarTx",
+				"reason", "already have a tx for this BundleID, height, and bundleOrder...",
+				"bundle id", txInfo.BundleID,
+				"bundle height", txInfo.DesiredHeight,
+				"bundle order", txInfo.BundleOrder,
+				"tx", tx.Hash(),
+			)
+			return true, nil
+		}
+		// if we added, then increment bundle size for BundleID
+		atomic.AddInt64(&bundle.CurrSize, int64(1))
+		return false, nil
+	}()
+	if err != nil {
+		return err
+	} else if shouldReturn {
+		return nil
+	}
+
+	// -------- UPDATE MAX BUNDLE ---------
+
+	func() {
+		sc.maxBundleIDMtx.Lock()
+		defer sc.maxBundleIDMtx.Unlock()
+		if txInfo.BundleID >= sc.maxBundleID {
+			sc.maxBundleID = txInfo.BundleID
+		}
+	}()
+
+	// -------- TX INSERTION INTO MAIN TXS LIST ---------
+	// -------- TODO: In the future probably want to refactor to not have txs clist ---------
+
+	e := sc.txs.PushBack(scTx)
+	sc.txsMap.Store(scTx.Tx.Key(), e)
+	atomic.AddInt64(&sc.txsBytes, int64(len(scTx.Tx)))
+
+	// add metric for new sidecar size
+	sc.metrics.SidecarSize.Set(float64(sc.Size()))
+
+	// add metric for sidecar tx sampling
+	sc.metrics.SidecarTxSizeBytes.Observe(float64(len(scTx.Tx)))
+
+	sc.lastBundleHeight = scTx.DesiredHeight
+
+	// TODO: in the future, refactor to only notifyTxsAvailable when we have at least one full bundle
+	if sc.Size() > 0 {
+		sc.notifyTxsAvailable()
+	}
+	sc.logger.Info(
+		"Added sidecar tx successfully",
+		"tx", tx,
+		"BundleID", txInfo.BundleID,
+		"bundleOrder", txInfo.BundleOrder,
+		"desiredHeight", txInfo.DesiredHeight,
+		"bundleSize", txInfo.BundleSize,
+		"sidecar total size", sc.Size(),
+	)
+
+	return nil
+}
+
+// Gets the height of the last received bundle tx. For status rpc purposes.
+func (sc *CListPriorityTxSidecar) GetLastBundleHeight() int64 {
+	if sc == nil {
+		return 0
+	}
+	return sc.lastBundleHeight
+}
+
+// TxsWaitChan returns a channel to wait on transactions. It will be closed
+// once the sidecar is not empty (ie. the internal `mem.txs` has at least one
+// element)
+//
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) TxsWaitChan() <-chan struct{} {
+	return sc.txs.WaitChan()
+}
+
+// TxsFront returns the first transaction in the ordered list for peer
+// goroutines to call .NextWait() on.
+// FIXME: leaking implementation details!
+//
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) TxsFront() *clist.CElement {
+	return sc.txs.Front()
+}
+
+// Lock() must be held by the caller during execution.
+func (sc *CListPriorityTxSidecar) Update(
+	height int64,
+	txs types.Txs,
+	deliverTxResponses []*abci.ResponseDeliverTx,
+) error {
+
+	// Set height for block last updated to (i.e. block last committed)
+	sc.height = height
+	sc.notifiedTxsAvailable = false
+	sc.heightForFiringAuction = height + 1
+
+	for i, tx := range txs {
+		if e, ok := sc.txsMap.Load(tx.Key()); ok {
+			if deliverTxResponses[i].Code == abci.CodeTypeOK {
+				sc.logger.Debug(
+					"removed valid commited tx from sidecar",
+					"tx", tx,
+					"mempool updated height", height,
+					"sidecar total size", sc.Size(),
+				)
+			} else {
+				sc.logger.Debug(
+					"removed invalid commited tx from sidecar",
+					"tx", tx,
+					"mempool updated height", height,
+					"sidecar total size", sc.Size(),
+				)
+			}
+			sc.removeTx(tx, e.(*clist.CElement), false)
+		}
+	}
+
+	sc.cache.Reset()
+	sc.maxBundleID = 0
+
+	// remove from txs list and txmap
+	for e := sc.txs.Front(); e != nil; e = e.Next() {
+		scTx := e.Value.(*mempool.SidecarTx)
+		if scTx.DesiredHeight <= height {
+			sc.logger.Debug(
+				"removed uncommited tx from sidecar",
+				"tx", scTx.Tx,
+				"tx desired height", scTx.DesiredHeight,
+				"mempool updated height", height,
+				"sidecar total size", sc.Size(),
+			)
+			tx := scTx.Tx
+			sc.removeTx(tx, e, false)
+		}
+	}
+
+	// remove the bundles
+	sc.bundles.Range(func(key, _ interface{}) bool {
+		if bundle, ok := sc.bundles.Load(key); ok {
+			bundle := bundle.(*mempool.Bundle)
+			if bundle.DesiredHeight <= height {
+				sc.logger.Debug(
+					"removed bundle from sidecar",
+					"bundle id", bundle.BundleID,
+					"tx desired height", bundle.DesiredHeight,
+					"mempool updated height", height,
+					"sidecar total size", sc.Size(),
+				)
+				sc.bundles.Delete(key)
+			}
+		}
+		return true
+	})
+
+	// add metric for new sidecar size
+	sc.metrics.SidecarSize.Set(float64(sc.Size()))
+
+	return nil
+}
+
+// Lock() must be help by the caller during execution.
+// Lock() must be help by the caller during execution.
+func (sc *CListPriorityTxSidecar) Flush() {
+	sc.cache.Reset()
+
+	sc.notifiedTxsAvailable = false
+	sc.maxBundleID = 0
+
+	_ = atomic.SwapInt64(&sc.txsBytes, 0)
+
+	for e := sc.txs.Front(); e != nil; e = e.Next() {
+		sc.txs.Remove(e)
+		e.DetachPrev()
+	}
+
+	sc.txsMap.Range(func(key, _ interface{}) bool {
+		sc.txsMap.Delete(key)
+		return true
+	})
+
+	sc.bundles.Range(func(key, _ interface{}) bool {
+		sc.bundles.Delete(key)
+		return true
+	})
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) Size() int {
+	return sc.txs.Len()
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) NumBundles() int {
+	i := 0
+	sc.bundles.Range(func(key, _ interface{}) bool {
+		i++
+		return true
+	})
+	return i
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) MaxBundleID() int64 {
+	return sc.maxBundleID
+}
+
+func (sc *CListPriorityTxSidecar) HeightForFiringAuction() int64 {
+	return sc.heightForFiringAuction
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) GetEnforcedBundleSize(bundleID int64) int {
+	if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleID}); ok {
+		bundle := bundle.(*mempool.Bundle)
+		return int(bundle.EnforcedSize)
+	}
+	sc.logger.Info(
+		"error GetEnforcedBundleSize: Don't have a bundle for bundleID",
+		"BundleID", bundleID,
+	)
+	return 0
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) GetCurrBundleSize(bundleID int64) int {
+	if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleID}); ok {
+		bundle := bundle.(*mempool.Bundle)
+		return int(bundle.CurrSize)
+	}
+	sc.logger.Info(
+		"error GetBundleSize: Don't have a bundle for bundleID",
+		"BundleID", bundleID,
+	)
+	return 0
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) TxsBytes() int64 {
+	return atomic.LoadInt64(&sc.txsBytes)
+}
+
+// Called from:
+//   - FlushSidecar (lock held) if tx was committed
+func (sc *CListPriorityTxSidecar) removeTx(tx types.Tx, elem *clist.CElement, removeFromCache bool) {
+	sc.txs.Remove(elem)
+	elem.DetachPrev()
+	sc.txsMap.Delete(tx.Key())
+	atomic.AddInt64(&sc.txsBytes, int64(-len(tx)))
+
+	if removeFromCache {
+		sc.cache.Remove(tx)
+	}
+}
+
+// Safe for concurrent use by multiple goroutines.
+
+// this reap function iterates over all the bundleIDs up to maxBundleID
+// ... then goes over each bundle via the bundleOrders (up to enforcedSize for bundle)
+// ... and reaps them in this order
+func (sc *CListPriorityTxSidecar) ReapMaxTxs() []*mempool.MempoolTx {
+	sc.updateMtx.RLock()
+	defer sc.updateMtx.RUnlock()
+
+	sc.logger.Info(
+		"Entering sidecar reap",
+		"sidecarSize", sc.Size(),
+	)
+
+	memTxs := make([]*mempool.MempoolTx, 0, sc.txs.Len())
+
+	if (sc.txs.Len() == 0) || (sc.NumBundles() == 0) {
+		return memTxs
+	}
+
+	completedBundles := 0
+	numTxsInBundles := 0
+
+	// iterate over all BundleIDs up to the max we've seen
+	// CONTRACT: this assumes that bundles don't care about previous bundles,
+	// so still want to execute if any missing between
+	for bundleIDIter := 0; bundleIDIter <= int(sc.maxBundleID); bundleIDIter++ {
+		bundleIDIter := int64(bundleIDIter)
+
+		if bundle, ok := sc.bundles.Load(Key{sc.heightForFiringAuction, bundleIDIter}); ok {
+			bundle := bundle.(*mempool.Bundle)
+			bundleOrderedTxsMap := bundle.OrderedTxsMap
+
+			// check to see if bundle is full, if not, just skip now
+			if bundle.CurrSize != bundle.EnforcedSize {
+				sc.logger.Info(
+					"In reap: skipping bundle, size mismatch",
+					"bundleID", bundleIDIter,
+					"height", sc.heightForFiringAuction,
+					"currSize", bundle.CurrSize,
+					"enforcedSize", bundle.EnforcedSize,
+				)
+				continue
+			}
+
+			// if full, iterate over bundle in order and add txs to temporary store, then add all if we have enough (i.e. matches enforcedBundleSize)
+			innerTxs := make([]*mempool.MempoolTx, 0, bundle.EnforcedSize)
+			for bundleOrderIter := 0; bundleOrderIter < int(bundle.EnforcedSize); bundleOrderIter++ {
+				bundleOrderIter := int64(bundleOrderIter)
+
+				if scTx, ok := bundleOrderedTxsMap.Load(bundleOrderIter); ok {
+					// loading as sidecar tx, but casting to MempoolTx to return
+					scTx := scTx.(*mempool.SidecarTx)
+					memTx := &mempool.MempoolTx{
+						// CONTRACT: since the only height this could have been added into is desiredHeight = mem.height + 1,
+						// then this tx must have been validated against mem.height
+						Height:    scTx.DesiredHeight - 1,
+						GasWanted: scTx.GasWanted,
+						Tx:        scTx.Tx,
+					}
+					innerTxs = append(innerTxs, memTx)
+				} else {
+					// can't find tx at this bundleOrder for this bundleID
+					sc.logger.Info(
+						"In reap: skipping bundle, don't have a tx for bundle",
+						"bundleID", bundleIDIter,
+						"bundleOrder", bundleOrderIter,
+						"height", sc.heightForFiringAuction,
+					)
+				}
+			}
+
+			// check to see if we have the right number of transactions for the bundle, comparing to the enforced size
+			if bundle.EnforcedSize == int64(len(innerTxs)) {
+				// check to see if we've reaped the right number of txs expected for the bundle
+				memTxs = append(memTxs, innerTxs...)
+				completedBundles++
+				numTxsInBundles += len(innerTxs)
+
+				// update metrics with total number of bundles reaped
+				sc.metrics.NumBundlesTotal.Add(1)
+			} else {
+				sc.logger.Info(
+					"In reap: skipping bundle, size mismatch",
+					"numTxsReaped", len(innerTxs),
+					"bundleCurrentSize", bundle.CurrSize,
+					"bundleEnforcedSize", bundle.EnforcedSize,
+					"bundleID", bundleIDIter,
+					"height", sc.heightForFiringAuction,
+				)
+			}
+		} else {
+			// can't find a bundle for this bundleID, skip! (incomplete gossipping)
+			sc.logger.Info(
+				"In reap: skipping bundle, don't have a bundle entry",
+				"bundleID", bundleIDIter,
+				"height", sc.heightForFiringAuction,
+			)
+		}
+	}
+
+	// update metrics with number of bundles reaped this block
+	sc.metrics.NumBundlesLastBlock.Set(float64(completedBundles))
+
+	// update metrics for number of mev transactions reaped this block
+	sc.metrics.NumMevTxsLastBlock.Set(float64(numTxsInBundles))
+
+	return memTxs
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) Lock() {
+	sc.updateMtx.Lock()
+}
+
+// Safe for concurrent use by multiple goroutines.
+func (sc *CListPriorityTxSidecar) Unlock() {
+	sc.updateMtx.Unlock()
+}

--- a/mempool/v0/clist_sidecar_test.go
+++ b/mempool/v0/clist_sidecar_test.go
@@ -1,0 +1,533 @@
+package v0
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tendermint/abci/example/kvstore"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/mempool"
+	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/types"
+)
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func addSpecificTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, txs types.Txs, peerID uint16) types.Txs {
+	bInfo := testBundleInfo{BundleSize: int64(len(txs)), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
+	for i := 0; i < len(txs); i++ {
+		err := sidecar.AddTx(txs[i], mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+			BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: int64(i)})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return txs
+}
+
+func addNumTxsToSidecarOneBundle(t *testing.T, sidecar mempool.PriorityTxSidecar, numTxs int, peerID uint16) types.Txs {
+	txs := make(types.Txs, numTxs)
+	bInfo := testBundleInfo{BundleSize: int64(numTxs), PeerID: peerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: 0}
+	for i := 0; i < numTxs; i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs = append(txs, txBytes)
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bundles []testBundleInfo, peerID uint16) {
+	for _, bundle := range bundles {
+		// createSidecarBundleWithTxs(t, sidecar, bundle.BundleSize, peerID, bundle.BundleID, bundle.DesiredHeight)
+		createSidecarBundleAndTxs(t, sidecar, bundle)
+	}
+}
+
+func TestSidecarUpdate(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// 1. Flushes the sidecar
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		err := sidecar.Update(0, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
+		require.NoError(t, err)
+		require.Equal(t, 2, sidecar.Size(), "foo with a newline should be written")
+		err = sidecar.Update(1, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK))
+		require.NoError(t, err)
+		require.Equal(t, 0, sidecar.Size(), "foo with a newline should be written")
+	}
+}
+
+func TestSidecarTxsAvailable(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+	sidecar.EnableTxsAvailable()
+
+	timeoutMS := 500
+
+	// with no txs, it shouldnt fire
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// send a bunch of txs, it should only fire once
+	txs := addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// call update with half the txs.
+	// it should fire once now for the new height
+	// since there are still txs left
+	txs = txs[50:]
+
+	// send a bunch more txs. we already fired for this height so it shouldnt fire again
+	moreTxs := addNumBundlesToSidecar(t, sidecar, 50, 10, mempool.UnknownPeerID)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// now call update with all the txs. it should not fire as there are no txs left
+	committedTxs := append(txs, moreTxs...) //nolint: gocritic
+	if err := sidecar.Update(2, committedTxs, abciResponses(len(committedTxs), abci.CodeTypeOK)); err != nil {
+		t.Error(err)
+	}
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+
+	// send a bunch more txs, it should only fire once
+	addNumBundlesToSidecar(t, sidecar, 100, 10, mempool.UnknownPeerID)
+	ensureFire(t, sidecar.TxsAvailable(), timeoutMS)
+	ensureNoFire(t, sidecar.TxsAvailable(), timeoutMS)
+}
+
+// TODO: shorten
+func TestReapSidecarWithTxsOutOfOrder(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// 1. Inserted out of order, but sequential, but bundleSize 1, so should get one tx
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    1,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    1,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		sidecar.PrettyPrintBundles()
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 1, len(txs), "Got %d txs, expected %d",
+			len(txs), 1)
+
+		sidecar.Flush()
+	}
+
+	// 2. Same as before but now size is open to 2, so expect 2
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 2, len(txs), "Got %d txs, expected %d",
+			len(txs), 2)
+
+		sidecar.Flush()
+	}
+
+	// 3. Insert a bundle out of order and non sequential, so nothing should happen
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    5,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		var bundleOrder int64 = 3
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    5,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
+			len(txs), 0)
+
+		sidecar.Flush()
+	}
+
+	// 4. Insert three successful bundles out of order
+	//nolint:dupl
+	{
+		bInfo := testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		var bundleOrder int64 = 2
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      1,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      1,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 7, len(txs), "Got %d txs, expected %d",
+			len(txs), 7)
+		sidecar.PrettyPrintBundles()
+
+		fmt.Println("TXS FROM REAP ----------")
+		for _, memTx := range txs {
+			fmt.Println(memTx.Tx.String())
+		}
+		fmt.Println("----------")
+
+		sidecar.Flush()
+	}
+
+	// 5. Multiple unsuccessful bundles, nothing reaped
+	//nolint:dupl
+	{
+		// size not filled
+		bInfo := testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		var bundleOrder int64
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      2,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		// wrong orders
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 2
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    3,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 1,
+			BundleID:      0,
+		}
+		bundleOrder = 3
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		// ============
+
+		// wrong heights
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 2,
+			BundleID:      1,
+		}
+		bundleOrder = 1
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		bInfo = testBundleInfo{
+			BundleSize:    2,
+			PeerID:        mempool.UnknownPeerID,
+			DesiredHeight: 0,
+			BundleID:      1,
+		}
+		bundleOrder = 0
+		addTxToSidecar(t, sidecar, bInfo, bundleOrder)
+
+		txs := sidecar.ReapMaxTxs()
+		assert.Equal(t, 0, len(txs), "Got %d txs, expected %d",
+			len(txs), 0)
+		sidecar.PrettyPrintBundles()
+
+		fmt.Println("TXS FROM REAP ----------")
+		for _, memTx := range txs {
+			fmt.Println(memTx.Tx.String())
+		}
+		fmt.Println("----------")
+
+		sidecar.Flush()
+	}
+}
+
+func TestBasicAddMultipleBundles(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	tests := []struct {
+		numBundlesTxsToCreate int
+	}{
+		{0},
+		{1},
+		{5},
+		{0},
+		{100},
+	}
+	for tcIndex, tt := range tests {
+		fmt.Println("Num bundles to create: ", tt.numBundlesTxsToCreate)
+		addNumBundlesToSidecar(t, sidecar, tt.numBundlesTxsToCreate, 10, mempool.UnknownPeerID)
+		sidecar.ReapMaxTxs()
+		assert.Equal(t, tt.numBundlesTxsToCreate, sidecar.NumBundles(), "Got %d bundles, expected %d, tc #%d",
+			sidecar.NumBundles(), tt.numBundlesTxsToCreate, tcIndex)
+		sidecar.Flush()
+	}
+}
+
+func TestSpecificAddTxsToMultipleBundles(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	// only one since no txs in first
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{0, 1, 0, 0},
+			{5, 1, 1, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 1)
+		sidecar.Flush()
+	}
+
+	// three bundles
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 5, 1, 0},
+			{5, 10, 1, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 3)
+		sidecar.Flush()
+	}
+
+	// only one bundle since we already have all these bundleOrders
+	{
+		// bundleSize, bundleHeight, bundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 1, 0, 0},
+			{5, 1, 0, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 1, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 1)
+		sidecar.Flush()
+	}
+
+	// only one bundle since we already have all these bundleOrders
+	{
+		// bundleSize, bundleHeight, BundleID, peerID
+		bundles := []testBundleInfo{
+			{5, 1, 0, 0},
+			{5, 1, 3, 0},
+			{5, 1, 5, 0},
+		}
+		addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+		assert.Equal(t, 3, sidecar.NumBundles(), "Got %d bundles, expected %d",
+			sidecar.NumBundles(), 3)
+		sidecar.Flush()
+	}
+}
+
+func TestGetEnforcedBundleSize(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	assert.Equal(t, 0, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 0, sidecar.GetEnforcedBundleSize(0))
+
+	bundles := []testBundleInfo{
+		{5, 1, 0, 0},
+	}
+	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	assert.Equal(t, 5, sidecar.GetEnforcedBundleSize(0), "Expected enforced bundle size %d, got %d", 5, sidecar.GetEnforcedBundleSize(0))
+}
+
+func TestGetCurrBundleSize(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	_, sidecar, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	assert.Equal(t, 0, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 0, sidecar.GetCurrBundleSize(0))
+
+	bundles := []testBundleInfo{
+		{5, 1, 0, 0},
+	}
+	addBundlesToSidecar(t, sidecar, bundles, mempool.UnknownPeerID)
+	assert.Equal(t, 5, sidecar.GetCurrBundleSize(0), "Expected curr bundle size %d, got %d", 5, sidecar.GetCurrBundleSize(0))
+}

--- a/mempool/v0/reactor_test.go
+++ b/mempool/v0/reactor_test.go
@@ -1,8 +1,10 @@
 package v0
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -63,7 +65,7 @@ func TestReactorBroadcastTxsMessage(t *testing.T) {
 		}
 	}
 
-	txs := checkTxs(t, reactors[0].mempool, numTxs, mempool.UnknownPeerID, reactors[0].sidecar, false)
+	txs := checkTxs(t, reactors[0].mempool, numTxs, mempool.UnknownPeerID)
 	waitForTxsOnReactors(t, txs, reactors, false)
 }
 
@@ -169,7 +171,7 @@ func TestReactorConcurrency(t *testing.T) {
 
 		// 1. submit a bunch of txs
 		// 2. update the whole mempool
-		txs := checkTxs(t, reactors[0].mempool, numTxs, mempool.UnknownPeerID, nil, false)
+		txs := checkTxs(t, reactors[0].mempool, numTxs, mempool.UnknownPeerID)
 		go func() {
 			defer wg.Done()
 
@@ -186,7 +188,7 @@ func TestReactorConcurrency(t *testing.T) {
 
 		// 1. submit a bunch of txs
 		// 2. update none
-		_ = checkTxs(t, reactors[1].mempool, numTxs, mempool.UnknownPeerID, nil, false)
+		_ = checkTxs(t, reactors[1].mempool, numTxs, mempool.UnknownPeerID)
 		go func() {
 			defer wg.Done()
 
@@ -223,7 +225,7 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	}
 
 	const peerID = 1
-	checkTxs(t, reactors[0].mempool, numTxs, peerID, nil, false)
+	checkTxs(t, reactors[0].mempool, numTxs, peerID)
 	ensureNoTxs(t, reactors[peerID], 100*time.Millisecond)
 }
 
@@ -417,7 +419,8 @@ func makeAndConnectReactorsEvensSidecar(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
-		mempool, sidecar, cleanup := newMempoolWithApp(cc)
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
 		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
@@ -439,7 +442,8 @@ func makeAndConnectReactors(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
-		mempool, sidecar, cleanup := newMempoolWithApp(cc)
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
 		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
@@ -504,8 +508,7 @@ func waitForSidecarTxsOnReactor(t *testing.T, txs types.Txs, reactor *Reactor, r
 
 	reapedTxs := sidecar.ReapMaxTxs()
 	var i int
-	for _, scMemTx := range reapedTxs {
-		scTx := scMemTx.Tx
+	for _, scTx := range reapedTxs.Txs {
 		assert.Equalf(t, txs[i], scTx,
 			"txs at index %d on reactor %d don't match: %s vs %s", i, reactorIndex, txs[i], scTx)
 		i++
@@ -541,4 +544,48 @@ func TestMempoolVectors(t *testing.T) {
 
 		require.Equal(t, tc.expBytes, hex.EncodeToString(bz), tc.testName)
 	}
+}
+
+// Sidecar testing utils
+
+type testBundleInfo struct {
+	BundleSize    int64
+	DesiredHeight int64
+	BundleID      int64
+	PeerID        uint16
+}
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
 }

--- a/mempool/v0/reactor_test.go
+++ b/mempool/v0/reactor_test.go
@@ -397,6 +397,154 @@ func TestLegacyReactorReceiveBasic(t *testing.T) {
 	})
 }
 
+func TestLegacyReactorReceiveSidecarMEVTxs(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 1
+	reactors := makeAndConnectReactors(config, N)
+	var (
+		reactor = reactors[0]
+		peer    = mock.NewPeer(nil)
+	)
+	defer func() {
+		err := reactor.Stop()
+		assert.NoError(t, err)
+	}()
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	txBytes := make([]byte, 20)
+	m := &memproto.MEVTxs{
+		Txs:           [][]byte{txBytes},
+		DesiredHeight: 1,
+		BundleId:      0,
+		BundleOrder:   0,
+		BundleSize:    1,
+	}
+	wm := m.Wrap()
+	msg, err := proto.Marshal(wm)
+	assert.NoError(t, err)
+	assert.NotPanics(t, func() {
+		reactor.Receive(mempool.SidecarLegacyChannel, peer, msg)
+		reactor.Receive(mempool.SidecarChannel, peer, msg)
+		waitForSidecarTxsOnReactor(t, []types.Tx{txBytes}, reactor, 0)
+	})
+}
+
+func TestReactorReceiveSidecarMEVTxs(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 1
+	reactors := makeAndConnectReactors(config, N)
+	var (
+		reactor = reactors[0]
+		peer    = mock.NewPeer(nil)
+	)
+	defer func() {
+		err := reactor.Stop()
+		assert.NoError(t, err)
+	}()
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	txBytes := make([]byte, 20)
+	m := &memproto.MEVTxs{
+		Txs:           [][]byte{txBytes},
+		DesiredHeight: 1,
+		BundleId:      0,
+		BundleOrder:   0,
+		BundleSize:    1,
+	}
+	assert.NotPanics(t, func() {
+		reactor.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: mempool.SidecarChannel,
+			Src:       peer,
+			Message:   m,
+		})
+		reactor.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: mempool.SidecarLegacyChannel,
+			Src:       peer,
+			Message:   m,
+		})
+		waitForSidecarTxsOnReactor(t, []types.Tx{txBytes}, reactor, 0)
+	})
+}
+
+func TestReactorReceiveSidecarMEVMessage(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 1
+	reactors := makeAndConnectReactors(config, N)
+	var (
+		reactor = reactors[0]
+		peer    = mock.NewPeer(nil)
+	)
+	defer func() {
+		err := reactor.Stop()
+		assert.NoError(t, err)
+	}()
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	txBytes := make([]byte, 20)
+	msg := &memproto.MEVMessage{
+		Sum: &memproto.MEVMessage_Txs{
+			Txs: &memproto.Txs{Txs: [][]byte{txBytes}},
+		},
+		DesiredHeight: 1,
+		BundleId:      0,
+		BundleOrder:   0,
+		BundleSize:    1,
+	}
+
+	assert.NotPanics(t, func() {
+		reactor.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: mempool.SidecarChannel,
+			Src:       peer,
+			Message:   msg,
+		})
+		reactor.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: mempool.SidecarLegacyChannel,
+			Src:       peer,
+			Message:   msg,
+		})
+		waitForSidecarTxsOnReactor(t, []types.Tx{txBytes}, reactor, 0)
+	})
+}
+
+func TestLegacyReactorReceiveSidecarMEVMessage(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 1
+	reactors := makeAndConnectReactors(config, N)
+	var (
+		reactor = reactors[0]
+		peer    = mock.NewPeer(nil)
+	)
+	defer func() {
+		err := reactor.Stop()
+		assert.NoError(t, err)
+	}()
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	txBytes := make([]byte, 20)
+	msg := &memproto.MEVMessage{
+		Sum: &memproto.MEVMessage_Txs{
+			Txs: &memproto.Txs{Txs: [][]byte{txBytes}},
+		},
+		DesiredHeight: 1,
+		BundleId:      0,
+		BundleOrder:   0,
+		BundleSize:    1,
+	}
+
+	mm, err := proto.Marshal(msg)
+	assert.NoError(t, err)
+	assert.NotPanics(t, func() {
+		reactor.Receive(mempool.SidecarLegacyChannel, peer, mm)
+		reactor.Receive(mempool.SidecarChannel, peer, mm)
+		fmt.Println(reactor.sidecar.Size())
+		waitForSidecarTxsOnReactor(t, []types.Tx{txBytes}, reactor, 0)
+	})
+}
+
 // mempoolLogger is a TestingLogger which uses a different
 // color for each validator ("validator" key must exist).
 func mempoolLogger() log.Logger {

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -321,7 +321,7 @@ func (txmp *TxMempool) allEntriesSorted() []*WrappedTx {
 //
 // If the mempool is empty or has no transactions fitting within the given
 // constraints, the result will also be empty.
-func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
+func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, nilTxs []*mempool.MempoolTx) types.Txs {
 	var totalGas, totalBytes int64
 
 	var keep []types.Tx //nolint:prealloc

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -321,10 +321,11 @@ func (txmp *TxMempool) allEntriesSorted() []*WrappedTx {
 //
 // If the mempool is empty or has no transactions fitting within the given
 // constraints, the result will also be empty.
-func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, nilTxs []*mempool.MempoolTx) types.Txs {
+func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.ReapedTxs {
 	var totalGas, totalBytes int64
 
-	var keep []types.Tx //nolint:prealloc
+	var keep []types.Tx    //nolint:prealloc
+	var gasWanteds []int64 //nolint:prealloc
 	for _, w := range txmp.allEntriesSorted() {
 		// N.B. When computing byte size, we need to include the overhead for
 		// encoding as protobuf to send to the application.
@@ -334,8 +335,12 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64, nilTxs []*memp
 			break
 		}
 		keep = append(keep, w.tx)
+		gasWanteds = append(gasWanteds, w.gasWanted)
 	}
-	return keep
+	return types.ReapedTxs{
+		Txs:        keep,
+		GasWanteds: gasWanteds,
+	}
 }
 
 // TxsWaitChan returns a channel that is closed when there is at least one

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -330,14 +330,14 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	}
 
 	// reap by gas capacity only
-	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50)
+	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, nil)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 50)
 
 	// reap by transaction bytes only
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1, nil)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -345,7 +345,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 
 	// Reap by both transaction bytes and gas, where the size yields 31 reaped
 	// transactions and the gas limit reaps 25 transactions.
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30, nil)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -330,14 +330,14 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	}
 
 	// reap by gas capacity only
-	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, nil)
+	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 50)
 
 	// reap by transaction bytes only
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1, nil)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -345,7 +345,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 
 	// Reap by both transaction bytes and gas, where the size yields 31 reaped
 	// transactions and the gas limit reaps 25 transactions.
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30, nil)
+	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30).Txs
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
 	require.Equal(t, int64(5690), txmp.SizeBytes())

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -140,9 +140,16 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 			MessageType:         &protomem.Message{},
 		},
 		{
+			ID:                  mempool.SidecarLegacyChannel,
+			Priority:            5,
+			RecvMessageCapacity: batchMsg.Size(),
+			MessageType:         &protomem.MEVMessage{},
+		},
+		{
 			ID:                  mempool.SidecarChannel,
 			Priority:            5,
 			RecvMessageCapacity: batchMsg.Size(),
+			MessageType:         &protomem.Message{},
 		},
 	}
 }
@@ -168,6 +175,9 @@ func (memR *Reactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 // It adds any received transactions to the mempool.
 func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 	memR.Logger.Debug("Receive", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+	isSidecarPeer := e.Src.IsSidecarPeer()
+	isLegacySidecarChannel := e.ChannelID == mempool.SidecarLegacyChannel
+	isSidecarChannel := e.ChannelID == mempool.SidecarChannel
 	switch msg := e.Message.(type) {
 	case *protomem.Txs:
 		protoTxs := msg.GetTxs()
@@ -190,6 +200,44 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 				memR.Logger.Info("Could not check tx", "tx", ntx.String(), "err", err)
 			}
 		}
+	case *protomem.MEVTxs:
+		protoTxs := msg.GetTxs()
+		if len(protoTxs) == 0 {
+			memR.Logger.Error("received empty txs from peer", "src", e.Src)
+			return
+		}
+		if isSidecarChannel {
+			memR.Logger.Error("received mev txs over incorrect channel", "src", e.Src, "chId", e.ChannelID)
+			return
+		}
+		if isSidecarPeer {
+			memR.Logger.Error("received mev txs from non-sidecar peer", "src", e.Src)
+			return
+		}
+		summary := MEVTxSummary{
+			Txs:           protoTxs,
+			DesiredHeight: msg.DesiredHeight,
+			BundleID:      msg.BundleId,
+			BundleOrder:   msg.BundleOrder,
+			BundleSize:    msg.BundleSize,
+		}
+		memR.InsertMEVTxInSidecar(summary, e.Src)
+	case *protomem.MEVMessage:
+		summary, err := memR.decodeLegacyMEVMessage(msg)
+		if err != nil {
+			memR.Logger.Error("failed to decode legacy mev message", "err", err)
+			return
+		}
+		if !isLegacySidecarChannel {
+			memR.Logger.Error("received legacy mev message over incorrect channel", "src", e.Src, "chId", e.ChannelID)
+			return
+		}
+		if !isSidecarPeer {
+			memR.Logger.Error("received legacy mev message from non-sidecar peer", "src", e.Src)
+			return
+		}
+		memR.InsertMEVTxInSidecar(summary, e.Src)
+
 	default:
 		memR.Logger.Error("unknown message type", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
 		memR.Switch.StopPeerForError(e.Src, fmt.Errorf("mempool cannot handle message of type: %T", e.Message))
@@ -200,20 +248,57 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (memR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	msg := &protomem.Message{}
-	err := proto.Unmarshal(msgBytes, msg)
-	if err != nil {
-		panic(err)
+	if chID == mempool.MempoolChannel || chID == mempool.SidecarChannel {
+		msg := &protomem.Message{}
+
+		err := proto.Unmarshal(msgBytes, msg)
+		if err != nil {
+			panic(err)
+		}
+		uw, err := msg.Unwrap()
+		if err != nil {
+			panic(err)
+		}
+		memR.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: chID,
+			Src:       peer,
+			Message:   uw,
+		})
+	} else if chID == mempool.SidecarLegacyChannel {
+		msg := &protomem.MEVMessage{}
+		err := proto.Unmarshal(msgBytes, msg)
+		if err != nil {
+			panic(err)
+		}
+		memR.ReceiveEnvelope(p2p.Envelope{
+			ChannelID: chID,
+			Src:       peer,
+			Message:   msg,
+		})
 	}
-	uw, err := msg.Unwrap()
-	if err != nil {
-		panic(err)
+}
+
+// Ingress a transaction to the sidecar along with txinfo object
+func (memR *Reactor) InsertMEVTxInSidecar(summary MEVTxSummary, peer p2p.Peer) {
+	txInfo := mempool.TxInfo{
+		SenderID:      memR.ids.GetForPeer(peer),
+		DesiredHeight: summary.DesiredHeight,
+		BundleID:      summary.BundleID,
+		BundleOrder:   summary.BundleOrder,
+		BundleSize:    summary.BundleSize,
 	}
-	memR.ReceiveEnvelope(p2p.Envelope{
-		ChannelID: chID,
-		Src:       peer,
-		Message:   uw,
-	})
+	if peer != nil {
+		txInfo.SenderP2PID = peer.ID()
+	}
+	for _, tx := range summary.Txs {
+		ntx := types.Tx(tx)
+		err := memR.sidecar.AddTx(ntx, txInfo)
+		if err == mempool.ErrTxInCache {
+			memR.Logger.Debug("sidecartx already exists in cache!", "tx", ntx.Hash())
+		} else if err != nil {
+			memR.Logger.Info("could not add SidecarTx", "tx", ntx.String(), "err", err)
+		}
+	}
 }
 
 // PeerState describes the state of a peer.
@@ -279,12 +364,29 @@ func (memR *Reactor) broadcastSidecarTxRoutine(peer p2p.Peer) {
 					BundleSize:    scTx.BundleSize,
 				}
 				success := p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
-					ChannelID: mempool.MempoolChannel,
+					ChannelID: mempool.SidecarChannel,
 					Message:   msg,
 				}, memR.Logger)
+				// if sending over envelop protocol fails, try over legacy protocol
 				if !success {
-					time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
-					continue
+					msg := &protomem.MEVMessage{
+						Sum: &protomem.MEVMessage_Txs{
+							Txs: &protomem.Txs{Txs: [][]byte{scTx.Tx}},
+						},
+						DesiredHeight: scTx.DesiredHeight,
+						BundleId:      scTx.BundleID,
+						BundleOrder:   scTx.BundleOrder,
+						BundleSize:    scTx.BundleSize,
+					}
+
+					success := p2p.SendEnvelopeShim(peer, p2p.Envelope{
+						ChannelID: mempool.SidecarLegacyChannel,
+						Message:   msg,
+					}, memR.Logger)
+					if !success {
+						time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
+						continue
+					}
 				}
 			} else {
 				memR.Logger.Info(
@@ -378,6 +480,43 @@ func (memR *Reactor) broadcastMempoolTxRoutine(peer p2p.Peer) {
 			return
 		}
 	}
+}
+
+func (memR *Reactor) decodeLegacyMEVMessage(lm *protomem.MEVMessage) (MEVTxSummary, error) {
+	var summary MEVTxSummary
+
+	if i, ok := lm.Sum.(*protomem.MEVMessage_Txs); ok {
+		txs := i.Txs.GetTxs()
+
+		if len(txs) == 0 {
+			return summary, errors.New("empty TxsMessage")
+		}
+
+		decoded := make([]types.Tx, len(txs))
+		for j, tx := range txs {
+			decoded[j] = types.Tx(tx)
+		}
+
+		summary = MEVTxSummary{
+			Txs:           txs,
+			DesiredHeight: lm.GetDesiredHeight(),
+			BundleID:      lm.GetBundleId(),
+			BundleOrder:   lm.GetBundleOrder(),
+			BundleSize:    lm.GetBundleSize(),
+		}
+		return summary, nil
+	}
+	return summary, fmt.Errorf("msg type: %T is not supported", lm)
+}
+
+// MEVTxsSummary is a data structure used to abstract MEV Txs
+// mempool insertion logic from the protobuf message they are received in
+type MEVTxSummary struct {
+	Txs           [][]byte
+	DesiredHeight int64
+	BundleID      int64
+	BundleOrder   int64
+	BundleSize    int64
 }
 
 //-----------------------------------------------------------------------------

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -206,11 +206,11 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 			memR.Logger.Error("received empty txs from peer", "src", e.Src)
 			return
 		}
-		if isSidecarChannel {
+		if !isSidecarChannel {
 			memR.Logger.Error("received mev txs over incorrect channel", "src", e.Src, "chId", e.ChannelID)
 			return
 		}
-		if isSidecarPeer {
+		if !isSidecarPeer {
 			memR.Logger.Error("received mev txs from non-sidecar peer", "src", e.Src)
 			return
 		}
@@ -253,11 +253,13 @@ func (memR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
 
 		err := proto.Unmarshal(msgBytes, msg)
 		if err != nil {
-			panic(err)
+			memR.Logger.Error("failed to unmarshal message", "err", err)
+			return
 		}
 		uw, err := msg.Unwrap()
 		if err != nil {
-			panic(err)
+			memR.Logger.Error("failed to unwrap message", "err", err)
+			return
 		}
 		memR.ReceiveEnvelope(p2p.Envelope{
 			ChannelID: chID,
@@ -268,7 +270,8 @@ func (memR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
 		msg := &protomem.MEVMessage{}
 		err := proto.Unmarshal(msgBytes, msg)
 		if err != nil {
-			panic(err)
+			memR.Logger.Error("failed to unmarshal message", "err", err)
+			return
 		}
 		memR.ReceiveEnvelope(p2p.Envelope{
 			ChannelID: chID,

--- a/mempool/v1/reactor_test.go
+++ b/mempool/v1/reactor_test.go
@@ -1,7 +1,9 @@
 package v1
 
 import (
+	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -67,7 +69,7 @@ func TestReactorBroadcastTxsMessage(t *testing.T) {
 		transactions[idx] = tx.tx
 	}
 
-	waitForTxsOnReactors(t, transactions, reactors)
+	waitForTxsOnReactors(t, transactions, reactors, false)
 }
 
 func TestMempoolVectors(t *testing.T) {
@@ -130,10 +132,11 @@ func makeAndConnectReactors(config *cfg.Config, n int) []*Reactor {
 	for i := 0; i < n; i++ {
 		app := kvstore.NewApplication()
 		cc := proxy.NewLocalClientCreator(app)
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
-		reactors[i] = NewReactor(config.Mempool, mempool) // so we dont start the consensus states
+		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
 		reactors[i].SetLogger(logger.With("validator", i))
 	}
 
@@ -178,14 +181,18 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, conf *cfg.Config) (*TxMe
 	return mp, func() { os.RemoveAll(conf.RootDir) }
 }
 
-func waitForTxsOnReactors(t *testing.T, txs types.Txs, reactors []*Reactor) {
+func waitForTxsOnReactors(t *testing.T, txs types.Txs, reactors []*Reactor, useSidecar bool) {
 	// wait for the txs in all mempools
 	wg := new(sync.WaitGroup)
 	for i, reactor := range reactors {
 		wg.Add(1)
 		go func(r *Reactor, reactorIndex int) {
 			defer wg.Done()
-			waitForTxsOnReactor(t, txs, r, reactorIndex)
+			if useSidecar {
+				waitForSidecarTxsOnReactor(t, txs, r, reactorIndex)
+			} else {
+				waitForTxsOnReactor(t, txs, r, reactorIndex)
+			}
 		}(reactor, i)
 	}
 
@@ -214,4 +221,164 @@ func waitForTxsOnReactor(t *testing.T, txs types.Txs, reactor *Reactor, reactorI
 		assert.Equalf(t, tx, reapedTxs[i],
 			"txs at index %d on reactor %d don't match: %v vs %v", i, reactorIndex, tx, reapedTxs[i])
 	}
+}
+
+func waitForSidecarTxsOnReactor(t *testing.T, txs types.Txs, reactor *Reactor, reactorIndex int) {
+	sidecar := reactor.sidecar
+	for sidecar.Size() < len(txs) {
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	reapedTxs := sidecar.ReapMaxTxs()
+	var i int
+	for _, scTx := range reapedTxs.Txs {
+		assert.Equalf(t, txs[i], scTx,
+			"txs at index %d on reactor %d don't match: %s vs %s", i, reactorIndex, txs[i], scTx)
+		i++
+	}
+}
+
+func TestReactorBroadcastSidecarOnly(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 8
+	reactors := makeAndConnectReactorsEvensSidecar(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors[2:3], true)
+	waitForTxsOnReactors(t, txs, reactors[4:5], true)
+	waitForTxsOnReactors(t, txs, reactors[6:7], true)
+	assert.Equal(t, 0, reactors[1].sidecar.Size())
+	assert.Equal(t, 0, reactors[5].sidecar.Size())
+	assert.Equal(t, 0, reactors[7].sidecar.Size())
+	assert.Equal(t, 0, reactors[3].sidecar.Size())
+}
+
+// Send a bunch of txs to the first reactor's sidecar and wait for them all to
+// be received in the others, IN THE RIGHT ORDER
+func TestReactorBroadcastSidecarTxsMessage(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 2
+	reactors := makeAndConnectReactors(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors, true)
+	reactors[1].sidecar.PrettyPrintBundles()
+}
+
+func TestReactorInsertOutOfOrderThenReap(t *testing.T) {
+	config := cfg.TestConfig()
+	const N = 2
+	reactors := makeAndConnectReactors(config, N)
+	defer func() {
+		for _, r := range reactors {
+			if err := r.Stop(); err != nil {
+				assert.NoError(t, err)
+			}
+		}
+	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
+	txs := addNumBundlesToSidecar(t, reactors[0].sidecar, 5, 10, mempool.UnknownPeerID)
+	time.Sleep(2000)
+	reactors[0].sidecar.PrettyPrintBundles()
+	waitForTxsOnReactors(t, txs, reactors, true)
+	reactors[1].sidecar.PrettyPrintBundles()
+}
+
+// connect N mempool reactors through N switches
+// can add additional logic to set which ones should be treated as sidecar
+// peers in p2p.Connect2Switches, including based on index
+func makeAndConnectReactorsEvensSidecar(config *cfg.Config, n int) []*Reactor {
+	reactors := make([]*Reactor, n)
+	logger := mempoolLogger()
+	for i := 0; i < n; i++ {
+		app := kvstore.NewApplication()
+		cc := proxy.NewLocalClientCreator(app)
+		sidecar := mempool.NewCListSidecar(0, log.NewNopLogger(), mempool.NopMetrics())
+		mempool, cleanup := newMempoolWithApp(cc)
+		defer cleanup()
+
+		reactors[i] = NewReactor(config.Mempool, mempool, sidecar) // so we dont start the consensus states
+		reactors[i].SetLogger(logger.With("validator", i))
+	}
+
+	p2p.MakeConnectedSwitches(config.P2P, n, func(i int, s *p2p.Switch) *p2p.Switch {
+		s.AddReactor("MEMPOOL", reactors[i])
+		return s
+
+	}, p2p.Connect2SwitchesEvensSidecar)
+	return reactors
+}
+
+// Sidecar testing utils
+
+type testBundleInfo struct {
+	BundleSize    int64
+	DesiredHeight int64
+	BundleID      int64
+	PeerID        uint16
+}
+
+func addNumBundlesToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, numBundles int, bundleSize int64, peerID uint16) types.Txs {
+	totalTxsCount := 0
+	txs := make(types.Txs, 0)
+	for i := 0; i < numBundles; i++ {
+		totalTxsCount += int(bundleSize)
+		newTxs := createSidecarBundleAndTxs(t, sidecar, testBundleInfo{BundleSize: bundleSize,
+			PeerID: mempool.UnknownPeerID, DesiredHeight: sidecar.HeightForFiringAuction(), BundleID: int64(i)})
+		txs = append(txs, newTxs...)
+	}
+	return txs
+}
+
+func createSidecarBundleAndTxs(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo) types.Txs {
+	txs := make(types.Txs, bInfo.BundleSize)
+	for i := 0; i < int(bInfo.BundleSize); i++ {
+		txBytes := addTxToSidecar(t, sidecar, bInfo, int64(i))
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func addTxToSidecar(t *testing.T, sidecar mempool.PriorityTxSidecar, bInfo testBundleInfo, bundleOrder int64) types.Tx {
+	txInfo := mempool.TxInfo{SenderID: bInfo.PeerID, BundleSize: bInfo.BundleSize,
+		BundleID: bInfo.BundleID, DesiredHeight: bInfo.DesiredHeight, BundleOrder: bundleOrder}
+	txBytes := make([]byte, 20)
+	_, err := rand.Read(txBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sidecar.AddTx(txBytes, txInfo); err != nil {
+		fmt.Println("Ignoring error in AddTx:", err)
+	}
+	return txBytes
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1451,7 +1451,7 @@ func makeNodeInfo(
 		Channels: []byte{
 			bcChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
-			mempl.MempoolChannel, mempl.SidecarChannel,
+			mempl.MempoolChannel, mempl.SidecarChannel, mempl.SidecarLegacyChannel,
 			evidence.EvidenceChannel,
 			statesync.SnapshotChannel, statesync.ChunkChannel,
 		},

--- a/node/node.go
+++ b/node/node.go
@@ -231,7 +231,7 @@ type Node struct {
 	indexerService    *txindex.IndexerService
 	prometheusSrv     *http.Server
 
-	sidecar *mempoolv0.CListPriorityTxSidecar
+	sidecar *mempl.CListPriorityTxSidecar
 }
 
 func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
@@ -375,6 +375,12 @@ func createMempoolAndSidecarAndMempoolReactor(
 	logger log.Logger,
 ) (mempl.Mempool, p2p.Reactor, mempl.PriorityTxSidecar) {
 
+	sidecar := mempl.NewCListSidecar(
+		state.LastBlockHeight,
+		logger,
+		memplMetrics,
+	)
+
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -390,12 +396,13 @@ func createMempoolAndSidecarAndMempoolReactor(
 		reactor := mempoolv1.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor, nil
+		return mp, reactor, sidecar
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -408,12 +415,6 @@ func createMempoolAndSidecarAndMempoolReactor(
 		)
 
 		mp.SetLogger(logger)
-
-		sidecar := mempoolv0.NewCListSidecar(
-			state.LastBlockHeight,
-			logger,
-			memplMetrics,
-		)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,
@@ -958,7 +959,7 @@ func NewNode(config *cfg.Config,
 		}()
 	}
 
-	typeAssertedSidecar, ok := sidecar.(*mempoolv0.CListPriorityTxSidecar)
+	typeAssertedSidecar, ok := sidecar.(*mempl.CListPriorityTxSidecar)
 	if !ok {
 		logger.Info("[node startup]: Creating node with nil sidecar")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -230,6 +230,8 @@ type Node struct {
 	blockIndexer      indexer.BlockIndexer
 	indexerService    *txindex.IndexerService
 	prometheusSrv     *http.Server
+
+	sidecar *mempoolv0.CListPriorityTxSidecar
 }
 
 func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
@@ -365,13 +367,14 @@ func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
 	return bytes.Equal(pubKey.Address(), addr)
 }
 
-func createMempoolAndMempoolReactor(
+func createMempoolAndSidecarAndMempoolReactor(
 	config *cfg.Config,
 	proxyApp proxy.AppConns,
 	state sm.State,
 	memplMetrics *mempl.Metrics,
 	logger log.Logger,
-) (mempl.Mempool, p2p.Reactor) {
+) (mempl.Mempool, p2p.Reactor, mempl.PriorityTxSidecar) {
+
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -392,7 +395,7 @@ func createMempoolAndMempoolReactor(
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor
+		return mp, reactor, nil
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -406,18 +409,25 @@ func createMempoolAndMempoolReactor(
 
 		mp.SetLogger(logger)
 
+		sidecar := mempoolv0.NewCListSidecar(
+			state.LastBlockHeight,
+			logger,
+			memplMetrics,
+		)
+
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor
+		return mp, reactor, sidecar
 
 	default:
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -564,6 +574,16 @@ func createTransport(
 	return transport, peerFilters
 }
 
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
 func createSwitch(config *cfg.Config,
 	transport p2p.Transport,
 	p2pMetrics *p2p.Metrics,
@@ -575,11 +595,26 @@ func createSwitch(config *cfg.Config,
 	evidenceReactor *evidence.Reactor,
 	nodeInfo p2p.NodeInfo,
 	nodeKey *p2p.NodeKey,
-	p2pLogger log.Logger,
-) *p2p.Switch {
+	p2pLogger log.Logger) *p2p.Switch {
+	peerList := splitAndTrimEmpty(config.Sidecar.PersonalPeerIDs, ",", " ")
+
+	if config.Sidecar.RelayerPeerString != "" {
+		relayerID := strings.Split(config.Sidecar.RelayerPeerString, "@")[0]
+		if !contains(peerList, relayerID) {
+			peerList = append(peerList, relayerID)
+		}
+	}
+
+	sidecarPeers, err := p2p.NewSidecarPeers(peerList)
+	if err != nil {
+		panic(fmt.Sprintln("Problem with peer initialization", err))
+	}
+
 	sw := p2p.NewSwitch(
 		config.P2P,
+		sidecarPeers,
 		transport,
+		config.Sidecar.RelayerPeerString,
 		p2p.WithMetrics(p2pMetrics),
 		p2p.SwitchPeerFilters(peerFilters...),
 	)
@@ -796,7 +831,7 @@ func NewNode(config *cfg.Config,
 	csMetrics, p2pMetrics, memplMetrics, smMetrics := metricsProvider(genDoc.ChainID)
 
 	// Make MempoolReactor
-	mempool, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
+	mempool, mempoolReactor, sidecar := createMempoolAndSidecarAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
 
 	// Make Evidence Reactor
 	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateDB, blockStore, logger)
@@ -811,6 +846,7 @@ func NewNode(config *cfg.Config,
 		proxyApp.Consensus(),
 		mempool,
 		evidencePool,
+		sidecar,
 		sm.BlockExecutorWithMetrics(smMetrics),
 	)
 
@@ -859,12 +895,35 @@ func NewNode(config *cfg.Config,
 		stateSyncReactor, consensusReactor, evidenceReactor, nodeInfo, nodeKey, p2pLogger,
 	)
 
-	err = sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
+	persistentPeers := splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " ")
+	err = sw.AddPersistentPeers(persistentPeers)
 	if err != nil {
 		return nil, fmt.Errorf("could not add peers from persistent_peers field: %w", err)
 	}
 
-	err = sw.AddUnconditionalPeerIDs(splitAndTrimEmpty(config.P2P.UnconditionalPeerIDs, ",", " "))
+	if config.Sidecar.RelayerPeerString != "" {
+		err = sw.AddRelayerPeer(config.Sidecar.RelayerPeerString)
+		if err != nil {
+			return nil, fmt.Errorf("could not add relayer from relayer_conn_string field: %w", err)
+		}
+	} else {
+		logger.Info("[node startup]: No relayer_conn_string specified, not adding relayer as peer")
+	}
+
+	unconditionalPeerIDs := splitAndTrimEmpty(config.P2P.UnconditionalPeerIDs, ",", " ")
+	if config.Sidecar.RelayerPeerString != "" {
+		splitStr := strings.Split(config.Sidecar.RelayerPeerString, "@")
+		if len(splitStr) > 0 {
+			relayerID := splitStr[0]
+			logger.Info("[node startup]: Adding relayer as an unconditional peer", relayerID)
+			unconditionalPeerIDs = append(unconditionalPeerIDs, relayerID)
+		} else {
+			fmt.Println("[node startup]: ERR: Could not parse relayer peer string",
+				" to add as unconditional peer, is it correctly configured?",
+				config.Sidecar.RelayerPeerString)
+		}
+	}
+	err = sw.AddUnconditionalPeerIDs(unconditionalPeerIDs)
 	if err != nil {
 		return nil, fmt.Errorf("could not add peer ids from unconditional_peer_ids field: %w", err)
 	}
@@ -899,6 +958,11 @@ func NewNode(config *cfg.Config,
 		}()
 	}
 
+	typeAssertedSidecar, ok := sidecar.(*mempoolv0.CListPriorityTxSidecar)
+	if !ok {
+		logger.Info("[node startup]: Creating node with nil sidecar")
+	}
+
 	node := &Node{
 		config:        config,
 		genesisDoc:    genDoc,
@@ -927,6 +991,7 @@ func NewNode(config *cfg.Config,
 		indexerService:   indexerService,
 		blockIndexer:     blockIndexer,
 		eventBus:         eventBus,
+		sidecar:          typeAssertedSidecar,
 	}
 	node.BaseService = *service.NewBaseService(logger, "Node", node)
 
@@ -946,8 +1011,30 @@ func (n *Node) OnStart() error {
 		time.Sleep(genTime.Sub(now))
 	}
 
+	// If all required info is set in config, register with sentinel
+	if n.config.Sidecar.APIKey != "" && n.config.Sidecar.RelayerRPCString != "" {
+		p2p.RegisterWithSentinel(n.Logger, n.config.Sidecar.APIKey,
+			string(n.nodeInfo.ID()), n.config.Sidecar.RelayerRPCString)
+	} else {
+		n.Logger.Info("[node startup]: Not registering with relayer, config has API Key:", n.config.Sidecar.APIKey,
+			"relayer rpc string:", n.config.Sidecar.RelayerRPCString)
+	}
+
 	// Add private IDs to addrbook to block those peers being added
-	n.addrBook.AddPrivateIDs(splitAndTrimEmpty(n.config.P2P.PrivatePeerIDs, ",", " "))
+	privateIDs := splitAndTrimEmpty(n.config.P2P.PrivatePeerIDs, ",", " ")
+	if n.config.Sidecar.RelayerPeerString != "" {
+		splitStr := strings.Split(n.config.Sidecar.RelayerPeerString, "@")
+		if len(splitStr) > 1 {
+			relayerID := splitStr[0]
+			n.Logger.Info("[node startup]: Adding relayer as a private peer", relayerID)
+			privateIDs = append(privateIDs, relayerID)
+		} else {
+			n.Logger.Info("[node startup]: ERR Could not parse relayer peer string ",
+				"to add as private peer, is it correctly configured?",
+				n.config.Sidecar.RelayerPeerString)
+		}
+	}
+	n.addrBook.AddPrivateIDs(privateIDs)
 
 	// Start the RPC server before the P2P server
 	// so we can eg. receive txs for the first block
@@ -982,7 +1069,13 @@ func (n *Node) OnStart() error {
 	}
 
 	// Always connect to persistent peers
-	err = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
+	peersToDialOnStartup := splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " ")
+	if n.config.Sidecar.RelayerPeerString != "" {
+		peersToDialOnStartup = append(peersToDialOnStartup, n.config.Sidecar.RelayerPeerString)
+	} else {
+		n.Logger.Info("[node startup]: No relayer_conn_string specified, not dialing relayer on startup")
+	}
+	err = n.sw.DialPeersAsync(peersToDialOnStartup)
 	if err != nil {
 		return fmt.Errorf("could not dial peers from persistent_peers field: %w", err)
 	}
@@ -1084,10 +1177,12 @@ func (n *Node) ConfigureRPC() error {
 		ConsensusReactor: n.consensusReactor,
 		EventBus:         n.eventBus,
 		Mempool:          n.mempool,
+		Sidecar:          n.sidecar,
 
 		Logger: n.Logger.With("module", "rpc"),
 
-		Config: *n.config.RPC,
+		Config:        *n.config.RPC,
+		SidecarConfig: *n.config.Sidecar,
 	})
 	if err := rpccore.InitGenesisChunks(); err != nil {
 		return err
@@ -1355,7 +1450,7 @@ func makeNodeInfo(
 		Channels: []byte{
 			bcChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
-			mempl.MempoolChannel,
+			mempl.MempoolChannel, mempl.SidecarChannel,
 			evidence.EvidenceChannel,
 			statesync.SnapshotChannel, statesync.ChunkChannel,
 		},

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -248,7 +248,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -258,7 +258,6 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -268,7 +267,6 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 
 	// Make EvidencePool
@@ -357,7 +355,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
-	var sidecar mempl.PriorityTxSidecar
+	sidecar := mempl.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
 		mempool = mempoolv0.NewCListMempool(config.Mempool,
@@ -366,7 +364,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
-		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -376,7 +373,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
-		sidecar = nil
 	}
 
 	// fill the mempool with one txs just below the maximum size

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -248,6 +248,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
+	var sidecar mempl.PriorityTxSidecar
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
@@ -257,6 +258,7 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -266,6 +268,7 @@ func TestCreateProposalBlock(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
+		sidecar = nil
 	}
 
 	// Make EvidencePool
@@ -304,6 +307,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		proxyApp.Consensus(),
 		mempool,
 		evidencePool,
+		sidecar,
 	)
 
 	commit := types.NewCommit(height-1, 0, types.BlockID{}, nil)
@@ -353,6 +357,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 	// Make Mempool
 	memplMetrics := mempl.NopMetrics()
 	var mempool mempl.Mempool
+	var sidecar mempl.PriorityTxSidecar
 	switch config.Mempool.Version {
 	case cfg.MempoolV0:
 		mempool = mempoolv0.NewCListMempool(config.Mempool,
@@ -361,6 +366,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv0.WithMetrics(memplMetrics),
 			mempoolv0.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)))
+		sidecar = mempoolv0.NewCListSidecar(state.LastBlockHeight, log.NewNopLogger(), memplMetrics)
 	case cfg.MempoolV1:
 		mempool = mempoolv1.NewTxMempool(logger,
 			config.Mempool,
@@ -370,6 +376,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 			mempoolv1.WithPreCheck(sm.TxPreCheck(state)),
 			mempoolv1.WithPostCheck(sm.TxPostCheck(state)),
 		)
+		sidecar = nil
 	}
 
 	// fill the mempool with one txs just below the maximum size
@@ -384,6 +391,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		proxyApp.Consensus(),
 		mempool,
 		sm.EmptyEvidencePool{},
+		sidecar,
 	)
 
 	commit := types.NewCommit(height-1, 0, types.BlockID{}, nil)

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -41,6 +41,8 @@ type Metrics struct {
 	MessageReceiveBytesTotal metrics.Counter
 	// Number of bytes of each message type sent.
 	MessageSendBytesTotal metrics.Counter
+	// Whether or not a node is connected to the relay.
+	RelayConnected metrics.Gauge
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -94,6 +96,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "message_send_bytes_total",
 			Help:      "Number of bytes of each message type sent.",
 		}, append(labels, "message_type")).With(labelsAndValues...),
+		RelayConnected: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "relay_connected",
+			Help:      "Whether or not a node is connected to the mev relay / sentinel. 1 if yes, 0 if no.",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -106,6 +114,7 @@ func NopMetrics() *Metrics {
 		NumTxs:                   discard.NewGauge(),
 		MessageReceiveBytesTotal: discard.NewCounter(),
 		MessageSendBytesTotal:    discard.NewCounter(),
+		RelayConnected:           discard.NewGauge(),
 	}
 }
 

--- a/p2p/mock/peer.go
+++ b/p2p/mock/peer.go
@@ -11,11 +11,11 @@ import (
 
 type Peer struct {
 	*service.BaseService
-	ip                   net.IP
-	id                   p2p.ID
-	addr                 *p2p.NetAddress
-	kv                   map[string]interface{}
-	Outbound, Persistent bool
+	ip                                net.IP
+	id                                p2p.ID
+	addr                              *p2p.NetAddress
+	kv                                map[string]interface{}
+	Outbound, Persistent, SidecarPeer bool
 }
 
 // NewPeer creates and starts a new mock peer. If the ip
@@ -30,10 +30,11 @@ func NewPeer(ip net.IP) *Peer {
 	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
 	netAddr.ID = nodeKey.ID()
 	mp := &Peer{
-		ip:   ip,
-		id:   nodeKey.ID(),
-		addr: netAddr,
-		kv:   make(map[string]interface{}),
+		ip:          ip,
+		id:          nodeKey.ID(),
+		addr:        netAddr,
+		kv:          make(map[string]interface{}),
+		SidecarPeer: true,
 	}
 	mp.BaseService = service.NewBaseService(nil, "MockPeer", mp)
 	if err := mp.Start(); err != nil {
@@ -72,3 +73,4 @@ func (mp *Peer) RemoteAddr() net.Addr        { return &net.TCPAddr{IP: mp.ip, Po
 func (mp *Peer) CloseConn() error            { return nil }
 func (mp *Peer) SetRemovalFailed()           {}
 func (mp *Peer) GetRemovalFailed() bool      { return false }
+func (mp *Peer) IsSidecarPeer() bool         { return mp.SidecarPeer }

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -123,27 +123,13 @@ func (_m *Peer) IsRunning() bool {
 	return r0
 }
 
-// SendEnvelope provides a mock function with given fields: _a0
-func (_m *Peer) SendEnvelope(_a0 p2p.Envelope) bool {
-	ret := _m.Called(_a0)
+// IsSidecarPeer provides a mock function with given fields:
+func (_m *Peer) IsSidecarPeer() bool {
+	ret := _m.Called()
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(p2p.Envelope) bool); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// TrySendEnvelope provides a mock function with given fields: _a0
-func (_m *Peer) TrySendEnvelope(_a0 p2p.Envelope) bool {
-	ret := _m.Called(_a0)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(p2p.Envelope) bool); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -377,13 +363,13 @@ func (_m *Peer) TrySend(_a0 byte, _a1 []byte) bool {
 	return r0
 }
 
-type NewPeerT interface {
+type mockConstructorTestingTNewPeer interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewPeer creates a new instance of Peer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewPeer(t NewPeerT) *Peer {
+func NewPeer(t mockConstructorTestingTNewPeer) *Peer {
 	mock := &Peer{}
 	mock.Mock.Test(t)
 

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -137,6 +137,34 @@ func (_m *Peer) IsSidecarPeer() bool {
 	return r0
 }
 
+// SendEnvelope provides a mock function with given fields: _a0
+func (_m *Peer) SendEnvelope(_a0 p2p.Envelope) bool {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(p2p.Envelope) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// TrySendEnvelope provides a mock function with given fields: _a0
+func (_m *Peer) TrySendEnvelope(_a0 p2p.Envelope) bool {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(p2p.Envelope) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // NodeInfo provides a mock function with given fields:
 func (_m *Peer) NodeInfo() p2p.NodeInfo {
 	ret := _m.Called()

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -329,7 +329,7 @@ func (na *NetAddress) ReachabilityTo(o *NetAddress) int {
 		case o.IP.To4() != nil:
 			return Ipv4
 		case tunneled:
-			// only prioritise ipv6 if we aren't tunnelling it.
+			// only prioritize ipv6 if we aren't tunnelling it.
 			return Ipv6Weak
 		}
 		return Ipv6Strong

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -18,24 +18,23 @@ type mockPeer struct {
 	id ID
 }
 
-func (mp *mockPeer) FlushStop()                      { mp.Stop() } //nolint:errcheck // ignore error
-func (mp *mockPeer) TrySendEnvelope(e Envelope) bool { return true }
-func (mp *mockPeer) SendEnvelope(e Envelope) bool    { return true }
-func (mp *mockPeer) TrySend(_ byte, _ []byte) bool   { return true }
-func (mp *mockPeer) Send(_ byte, _ []byte) bool      { return true }
-func (mp *mockPeer) NodeInfo() NodeInfo              { return DefaultNodeInfo{} }
-func (mp *mockPeer) Status() ConnectionStatus        { return ConnectionStatus{} }
-func (mp *mockPeer) ID() ID                          { return mp.id }
-func (mp *mockPeer) IsOutbound() bool                { return false }
-func (mp *mockPeer) IsPersistent() bool              { return true }
-func (mp *mockPeer) Get(s string) interface{}        { return s }
-func (mp *mockPeer) Set(string, interface{})         {}
-func (mp *mockPeer) RemoteIP() net.IP                { return mp.ip }
-func (mp *mockPeer) SocketAddr() *NetAddress         { return nil }
-func (mp *mockPeer) RemoteAddr() net.Addr            { return &net.TCPAddr{IP: mp.ip, Port: 8800} }
-func (mp *mockPeer) CloseConn() error                { return nil }
-func (mp *mockPeer) SetRemovalFailed()               {}
-func (mp *mockPeer) GetRemovalFailed() bool          { return false }
+func (mp *mockPeer) FlushStop()                              { mp.Stop() } //nolint:errcheck // ignore error
+func (mp *mockPeer) TrySend(chID byte, msgBytes []byte) bool { return true }
+func (mp *mockPeer) Send(chID byte, msgBytes []byte) bool    { return true }
+func (mp *mockPeer) NodeInfo() NodeInfo                      { return DefaultNodeInfo{} }
+func (mp *mockPeer) Status() ConnectionStatus                { return ConnectionStatus{} }
+func (mp *mockPeer) ID() ID                                  { return mp.id }
+func (mp *mockPeer) IsOutbound() bool                        { return false }
+func (mp *mockPeer) IsPersistent() bool                      { return true }
+func (mp *mockPeer) IsSidecarPeer() bool                     { return true }
+func (mp *mockPeer) Get(s string) interface{}                { return s }
+func (mp *mockPeer) Set(string, interface{})                 {}
+func (mp *mockPeer) RemoteIP() net.IP                        { return mp.ip }
+func (mp *mockPeer) SocketAddr() *NetAddress                 { return nil }
+func (mp *mockPeer) RemoteAddr() net.Addr                    { return &net.TCPAddr{IP: mp.ip, Port: 8800} }
+func (mp *mockPeer) CloseConn() error                        { return nil }
+func (mp *mockPeer) SetRemovalFailed()                       {}
+func (mp *mockPeer) GetRemovalFailed() bool                  { return false }
 
 // Returns a mock peer
 func newMockPeer(ip net.IP) *mockPeer {

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -99,7 +99,7 @@ func createOutboundPeerAndPerformHandshake(
 		return nil, err
 	}
 
-	p := newPeer(pc, mConfig, peerNodeInfo, reactorsByCh, msgTypeByChID, chDescs, func(p Peer, r interface{}) {}, newMetricsLabelCache())
+	p := newPeer(pc, mConfig, peerNodeInfo, reactorsByCh, msgTypeByChID, chDescs, true, func(p Peer, r interface{}) {}, newMetricsLabelCache())
 	p.SetLogger(log.TestingLogger().With("peer", addr))
 	return p, nil
 }

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -770,7 +770,7 @@ func countOldAndNewAddrsInSelection(addrs []*p2p.NetAddress, book *addrBook) (nO
 	return
 }
 
-// Analyse the layout of the selection specified by 'addrs'
+// Analyze the layout of the selection specified by 'addrs'
 // Returns:
 // - seqLens - the lengths of the sequences of addresses of same type
 // - seqTypes - the types of sequences in selection

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -508,7 +508,7 @@ func (r *Reactor) ensurePeers() {
 		}
 		// TODO: consider moving some checks from toDial into here
 		// so we don't even consider dialing peers that we want to wait
-		// before dialling again, or have dialed too many times already
+		// before dialing again, or have dialed too many times already
 		toDial[try.ID] = try
 	}
 

--- a/p2p/sentinel.go
+++ b/p2p/sentinel.go
@@ -1,0 +1,100 @@
+package p2p
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
+)
+
+func RegisterWithSentinel(logger log.Logger, APIKey, peerID, sentinel string) {
+	logger.Info(
+		"[p2p.sentinel]: Registering with sentinel (first try)",
+		"API Key", APIKey,
+		"peerID", peerID,
+		"sentinel string", sentinel,
+	)
+
+	jsonData, err := makePostRequestData(peerID, APIKey)
+	if err != nil {
+		logger.Info("[p2p.sentinel]: Err marshalling json data:", err)
+		return
+	}
+
+	go postRequestRoutine(logger, sentinel, jsonData)
+}
+
+func attemptRegisterOnce(logger log.Logger, sentinel string, jsonData []byte) error {
+	client := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Post(sentinel, "application/json", bytes.NewBuffer(jsonData)) //nolint:gosec
+	if err != nil {
+		logger.Info("[p2p.sentinel]: Err registering with sentinel", "err", err.Error())
+		return err
+	}
+	if resp == nil {
+		logger.Info("[p2p.sentinel]: No response from sentinel", "err", err.Error())
+		return errors.New("no response from sentinel")
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.Info("[p2p.sentinel]: Bad status code from sentinel", "status code", resp.StatusCode)
+		return errors.New("bad status code from sentinel")
+	}
+	if resp.Body == nil {
+		logger.Info("[p2p.sentinel]: No body in response from sentinel", "err", err.Error())
+
+		return errors.New("no body in response from sentinel")
+	}
+	defer resp.Body.Close()
+
+	unmarshalledResponse := &types.RPCResponse{}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Info("[p2p.sentinel]: error reading body", "err", err)
+		return errors.New("error reading response body")
+	}
+	err = json.Unmarshal(bodyBytes, unmarshalledResponse)
+	if err != nil {
+		logger.Info("[p2p.sentinel]: error unmarshalling response body", "err", err)
+		return errors.New("error unmarshalling response body")
+	}
+	if unmarshalledResponse.Error != nil {
+		logger.Info("[p2p.sentinel]: error from sentinel rpc", "err", unmarshalledResponse.Error)
+		return errors.New("error in response body")
+	}
+	return nil
+}
+
+func postRequestRoutine(logger log.Logger, sentinel string, jsonData []byte) {
+	tries := 1
+	for {
+		logger.Info("[p2p.sentinel]: Attempt to reregister via Sentinel API",
+			"try #", tries,
+		)
+		err := attemptRegisterOnce(logger, sentinel, jsonData)
+		if err == nil {
+			logger.Info("[p2p.sentinel]: Successfully registered with Sentinel API")
+			return
+		}
+		logger.Info("[p2p.sentinel]: Failed to register with Sentinel API", "err", err)
+		time.Sleep(30 * time.Second)
+		tries++
+	}
+}
+
+func makePostRequestData(peerID, APIKey string) ([]byte, error) {
+	params := [2]string{peerID, APIKey}
+	data := map[string]interface{}{
+		"method": "register_node_api",
+		"params": params,
+		"id":     1,
+	}
+
+	return json.Marshal(data)
+}

--- a/p2p/sentinel.go
+++ b/p2p/sentinel.go
@@ -22,7 +22,7 @@ func RegisterWithSentinel(logger log.Logger, APIKey, peerID, sentinel string) {
 
 	jsonData, err := makePostRequestData(peerID, APIKey)
 	if err != nil {
-		logger.Info("[p2p.sentinel]: Err marshalling json data:", err)
+		logger.Info("[p2p.sentinel]: Err marshaling json data:", err)
 		return
 	}
 
@@ -33,7 +33,7 @@ func attemptRegisterOnce(logger log.Logger, sentinel string, jsonData []byte) er
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	resp, err := client.Post(sentinel, "application/json", bytes.NewBuffer(jsonData)) //nolint:gosec
+	resp, err := client.Post(sentinel, "application/json", bytes.NewBuffer(jsonData)) //nolint: gosec
 	if err != nil {
 		logger.Info("[p2p.sentinel]: Err registering with sentinel", "err", err.Error())
 		return err

--- a/p2p/sentinel_test.go
+++ b/p2p/sentinel_test.go
@@ -1,0 +1,101 @@
+package p2p
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestPostRequestRoutine(t *testing.T) {
+	// Make a mock http server to receive the register request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.URL.Path != "/" {
+			t.Errorf("Expected to request '/', got: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Accept: application/json header, got: %s", r.Header.Get("Accept"))
+		}
+
+		bodyBytes := make([]byte, 100)
+		n, _ := r.Body.Read(bodyBytes)
+
+		var body map[string]interface{}
+		err := json.Unmarshal(bodyBytes[:n], &body)
+		if err != nil {
+			t.Errorf("Erred while unmarshalling body: %s", err)
+		}
+
+		if id := body["id"].(float64); id != float64(1) {
+			t.Errorf("Expected post body to have id=%f, got %f", float64(1), id)
+		}
+		if method := body["method"].(string); method != "register_node_api" {
+			t.Errorf("Expected post body to have method=%s, got %s", "add_node_api", method)
+		}
+		params := body["params"].([]interface{})
+		if peerID := params[0].(string); peerID != "a1b2c3d4" {
+			t.Errorf("Expected post body params to have peerID %s, got %s", "a1b2c3d4", peerID)
+		}
+		if apikey := params[1].(string); apikey != "test-api-key" {
+			t.Errorf("Expected post body params to have apikey %s, got %s", "test-api-key", apikey)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(`{"jsonrpc": "2.0", "id": 1, "result": "success"}`))
+		if err != nil {
+			t.Errorf("Error writing response: %s", err)
+		}
+	}))
+	defer server.Close()
+
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	postRequestRoutine(log.NewNopLogger(), server.URL, jsonData)
+}
+
+func TestPostRequestRoutine_DoesNotPanicOn500(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexpected panic from postRequestRoutine")
+		}
+	}()
+
+	// Make a mock http server to receive the register request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	err := attemptRegisterOnce(log.NewNopLogger(), server.URL, jsonData)
+	if err == nil {
+		t.Errorf("Expected error on fake server")
+	}
+}
+
+func TestErrorOnJSONRPCError(t *testing.T) {
+	// Make a mock http server to receive the register request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"jsonrpc": "2.0", "id": 1, "error": "some error"}`))
+		if err != nil {
+			t.Errorf("Error writing response: %s", err)
+		}
+	}))
+	defer server.Close()
+
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	err := attemptRegisterOnce(log.NewNopLogger(), server.URL, jsonData)
+	if err == nil {
+		t.Errorf("Expected error on jsonrpc error")
+	}
+}
+
+func TestErrorOnFailedToRespond(t *testing.T) {
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	err := attemptRegisterOnce(log.NewNopLogger(), "http://1.2.3.4:6969", jsonData)
+	if err == nil {
+		t.Errorf("Expected error on fake server")
+	}
+}

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -221,6 +221,14 @@ func assertMsgReceivedWithTimeout(
 	}
 }
 
+func TestSidecarPeerMap(t *testing.T) {
+	s1 := MakeSwitch(cfg, 1, "127.0.0.1", "123.123.123", initSwitchFunc)
+	s1id := string(s1.nodeInfo.ID())
+	sp, _ := NewSidecarPeers([]string{s1id})
+	s2 := MakeSwitchWithSidecarPeers(cfg, 2, "127.0.0.1", "123.123.124", initSwitchFunc, sp)
+	assert.True(t, s2.IsSidecarPeer(s1.nodeInfo.ID()))
+}
+
 func TestSwitchFiltersOutItself(t *testing.T) {
 	s1 := MakeSwitch(cfg, 1, "127.0.0.1", "123.123.123", initSwitchFunc)
 
@@ -732,7 +740,7 @@ func (errorTransport) Cleanup(Peer) {
 }
 
 func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
-	sw := NewSwitch(cfg, errorTransport{ErrFilterTimeout{}})
+	sw := NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrFilterTimeout{}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
 		require.NoError(t, err)
@@ -740,7 +748,8 @@ func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	sw = NewSwitch(cfg, errorTransport{ErrRejected{conn: nil, err: errors.New("filtered"), isFiltered: true}})
+	sw = NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrRejected{
+		conn: nil, err: errors.New("filtered"), isFiltered: true}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
 		require.NoError(t, err)
@@ -749,7 +758,7 @@ func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
 	})
 	// TODO(melekes) check we remove our address from addrBook
 
-	sw = NewSwitch(cfg, errorTransport{ErrTransportClosed{}})
+	sw = NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrTransportClosed{}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
 		require.NoError(t, err)
@@ -890,4 +899,21 @@ func TestSwitchRemovalErr(t *testing.T) {
 	sw2.StopPeerForError(p, fmt.Errorf("peer should error"))
 
 	assert.Equal(t, sw2.peers.Add(p).Error(), ErrPeerRemoval{}.Error())
+}
+
+func TestAddRelayerPeer(t *testing.T) {
+	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
+	relayerString := "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656"
+	relayerNetAddr, _ := NewNetAddressString(relayerString)
+
+	err := sw.AddRelayerPeer(relayerString)
+	if err != nil {
+		t.Errorf("Err in AddRelayerPeer: %s", err)
+	}
+
+	assert.Equal(t, relayerNetAddr, sw.RelayerNetAddr, "Expected RelayerNetAddr %s, got %s", relayerNetAddr, sw.RelayerNetAddr)
+
+	errRelayerString := "abcd@1.2.3.4:26656"
+	err = sw.AddRelayerPeer(errRelayerString)
+	assert.True(t, err != nil, "Expected err with invalid relayer string")
 }

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -110,14 +110,14 @@ func Connect2Switches(switches []*Switch, i, j int) {
 
 	doneCh := make(chan struct{})
 	go func() {
-		err := switchI.addPeerWithConnection(c1)
+		err := switchI.addPeerWithConnection(c1, true)
 		if err != nil {
 			panic(err)
 		}
 		doneCh <- struct{}{}
 	}()
 	go func() {
-		err := switchJ.addPeerWithConnection(c2)
+		err := switchJ.addPeerWithConnection(c2, true)
 		if err != nil {
 			panic(err)
 		}
@@ -127,7 +127,33 @@ func Connect2Switches(switches []*Switch, i, j int) {
 	<-doneCh
 }
 
-func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
+func Connect2SwitchesEvensSidecar(switches []*Switch, i, j int) {
+	switchI := switches[i]
+	switchJ := switches[j]
+	skipSetting := (i%2 == 0) && (j%2 == 0)
+
+	c1, c2 := conn.NetPipe()
+
+	doneCh := make(chan struct{})
+	go func() {
+		err := switchI.addPeerWithConnection(c1, skipSetting)
+		if err != nil {
+			panic(err)
+		}
+		doneCh <- struct{}{}
+	}()
+	go func() {
+		err := switchJ.addPeerWithConnection(c2, skipSetting)
+		if err != nil {
+			panic(err)
+		}
+		doneCh <- struct{}{}
+	}()
+	<-doneCh
+	<-doneCh
+}
+
+func (sw *Switch) addPeerWithConnection(conn net.Conn, skip bool) error {
 	pc, err := testInboundPeerConn(conn, sw.config, sw.nodeKey.PrivKey)
 	if err != nil {
 		if err := conn.Close(); err != nil {
@@ -151,6 +177,7 @@ func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 		sw.reactorsByCh,
 		sw.msgTypeByChID,
 		sw.chDescs,
+		skip,
 		sw.StopPeerForError,
 		sw.mlc,
 	)
@@ -173,6 +200,50 @@ func StartSwitches(switches []*Switch) error {
 		}
 	}
 	return nil
+}
+
+func MakeSwitchWithSidecarPeers(
+	cfg *config.P2PConfig,
+	i int,
+	network, version string,
+	initSwitch func(int, *Switch) *Switch,
+	sp SidecarPeers,
+	opts ...SwitchOption,
+) *Switch {
+
+	nodeKey := NodeKey{
+		PrivKey: ed25519.GenPrivKey(),
+	}
+	nodeInfo := testNodeInfo(nodeKey.ID(), fmt.Sprintf("node%d", i))
+	addr, err := NewNetAddressString(
+		IDAddressString(nodeKey.ID(), nodeInfo.(DefaultNodeInfo).ListenAddr),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	t := NewMultiplexTransport(nodeInfo, nodeKey, MConnConfig(cfg))
+
+	if err := t.Listen(*addr); err != nil {
+		panic(err)
+	}
+
+	sw := initSwitch(i, NewSwitch(cfg, sp, t, "", opts...))
+	sw.SetLogger(log.TestingLogger().With("switch", i))
+	sw.SetNodeKey(&nodeKey)
+
+	ni := nodeInfo.(DefaultNodeInfo)
+	for ch := range sw.reactorsByCh {
+		ni.Channels = append(ni.Channels, ch)
+	}
+	nodeInfo = ni
+
+	// TODO: We need to setup reactors ahead of time so the NodeInfo is properly
+	// populated and we don't have to do those awkward overrides and setters.
+	t.nodeInfo = nodeInfo
+	sw.SetNodeInfo(nodeInfo)
+
+	return sw
 }
 
 func MakeSwitch(
@@ -201,7 +272,7 @@ func MakeSwitch(
 	}
 
 	// TODO: let the config be passed in?
-	sw := initSwitch(i, NewSwitch(cfg, t, opts...))
+	sw := initSwitch(i, NewSwitch(cfg, make(SidecarPeers, 0), t, "", opts...))
 	sw.SetLogger(log.TestingLogger().With("switch", i))
 	sw.SetNodeKey(&nodeKey)
 

--- a/proto/tendermint/crypto/keys.pb.go
+++ b/proto/tendermint/crypto/keys.pb.go
@@ -27,6 +27,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // PublicKey defines the keys available for use with Tendermint Validators
 type PublicKey struct {
 	// Types that are valid to be assigned to Sum:
+	//
 	//	*PublicKey_Ed25519
 	//	*PublicKey_Secp256K1
 	Sum isPublicKey_Sum `protobuf_oneof:"sum"`

--- a/proto/tendermint/mempool/message.go
+++ b/proto/tendermint/mempool/message.go
@@ -8,6 +8,7 @@ import (
 )
 
 var _ p2p.Wrapper = &Txs{}
+var _ p2p.Wrapper = &MEVTxs{}
 var _ p2p.Unwrapper = &Message{}
 
 // Wrap implements the p2p Wrapper interface and wraps a mempool message.
@@ -17,13 +18,21 @@ func (m *Txs) Wrap() proto.Message {
 	return mm
 }
 
+// Wrap implements the p2p Wrapper interface and wraps a mempool message
+func (m *MEVTxs) Wrap() proto.Message {
+	mm := &Message{}
+	mm.Sum = &Message_MevTxs{MevTxs: m}
+	return mm
+}
+
 // Unwrap implements the p2p Wrapper interface and unwraps a wrapped mempool
 // message.
 func (m *Message) Unwrap() (proto.Message, error) {
 	switch msg := m.Sum.(type) {
 	case *Message_Txs:
 		return m.GetTxs(), nil
-
+	case *Message_MevTxs:
+		return m.GetMevTxs(), nil
 	default:
 		return nil, fmt.Errorf("unknown message: %T", msg)
 	}

--- a/proto/tendermint/mempool/types.pb.go
+++ b/proto/tendermint/mempool/types.pb.go
@@ -152,6 +152,111 @@ func (*Message) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+type MEVMessage struct {
+	// Types that are valid to be assigned to Sum:
+	//
+	//	*MEVMessage_Txs
+	Sum           isMEVMessage_Sum `protobuf_oneof:"sum"`
+	DesiredHeight int64            `protobuf:"varint,2,opt,name=desired_height,json=desiredHeight,proto3" json:"desired_height,omitempty"`
+	BundleId      int64            `protobuf:"varint,3,opt,name=bundle_id,json=bundleId,proto3" json:"bundle_id,omitempty"`
+	BundleOrder   int64            `protobuf:"varint,4,opt,name=bundle_order,json=bundleOrder,proto3" json:"bundle_order,omitempty"`
+	BundleSize    int64            `protobuf:"varint,5,opt,name=bundle_size,json=bundleSize,proto3" json:"bundle_size,omitempty"`
+}
+
+func (m *MEVMessage) Reset()         { *m = MEVMessage{} }
+func (m *MEVMessage) String() string { return proto.CompactTextString(m) }
+func (*MEVMessage) ProtoMessage()    {}
+func (*MEVMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2af51926fdbcbc05, []int{2}
+}
+func (m *MEVMessage) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MEVMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MEVMessage.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MEVMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MEVMessage.Merge(m, src)
+}
+func (m *MEVMessage) XXX_Size() int {
+	return m.Size()
+}
+func (m *MEVMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_MEVMessage.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MEVMessage proto.InternalMessageInfo
+
+type isMEVMessage_Sum interface {
+	isMEVMessage_Sum()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type MEVMessage_Txs struct {
+	Txs *Txs `protobuf:"bytes,1,opt,name=txs,proto3,oneof" json:"txs,omitempty"`
+}
+
+func (*MEVMessage_Txs) isMEVMessage_Sum() {}
+
+func (m *MEVMessage) GetSum() isMEVMessage_Sum {
+	if m != nil {
+		return m.Sum
+	}
+	return nil
+}
+
+func (m *MEVMessage) GetTxs() *Txs {
+	if x, ok := m.GetSum().(*MEVMessage_Txs); ok {
+		return x.Txs
+	}
+	return nil
+}
+
+func (m *MEVMessage) GetDesiredHeight() int64 {
+	if m != nil {
+		return m.DesiredHeight
+	}
+	return 0
+}
+
+func (m *MEVMessage) GetBundleId() int64 {
+	if m != nil {
+		return m.BundleId
+	}
+	return 0
+}
+
+func (m *MEVMessage) GetBundleOrder() int64 {
+	if m != nil {
+		return m.BundleOrder
+	}
+	return 0
+}
+
+func (m *MEVMessage) GetBundleSize() int64 {
+	if m != nil {
+		return m.BundleSize
+	}
+	return 0
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MEVMessage) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*MEVMessage_Txs)(nil),
+	}
+}
+
 type MEVTxs struct {
 	Txs           [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	DesiredHeight int64    `protobuf:"varint,2,opt,name=desired_height,json=desiredHeight,proto3" json:"desired_height,omitempty"`
@@ -164,7 +269,7 @@ func (m *MEVTxs) Reset()         { *m = MEVTxs{} }
 func (m *MEVTxs) String() string { return proto.CompactTextString(m) }
 func (*MEVTxs) ProtoMessage()    {}
 func (*MEVTxs) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2af51926fdbcbc05, []int{2}
+	return fileDescriptor_2af51926fdbcbc05, []int{3}
 }
 func (m *MEVTxs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -231,33 +336,35 @@ func (m *MEVTxs) GetBundleSize() int64 {
 func init() {
 	proto.RegisterType((*Txs)(nil), "tendermint.mempool.Txs")
 	proto.RegisterType((*Message)(nil), "tendermint.mempool.Message")
+	proto.RegisterType((*MEVMessage)(nil), "tendermint.mempool.MEVMessage")
 	proto.RegisterType((*MEVTxs)(nil), "tendermint.mempool.MEVTxs")
 }
 
 func init() { proto.RegisterFile("tendermint/mempool/types.proto", fileDescriptor_2af51926fdbcbc05) }
 
 var fileDescriptor_2af51926fdbcbc05 = []byte{
-	// 307 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xc1, 0x4a, 0x2b, 0x31,
-	0x14, 0x86, 0x27, 0x37, 0xb7, 0xad, 0x9e, 0x56, 0x91, 0x6c, 0x3a, 0x28, 0x44, 0x2d, 0x08, 0x05,
-	0x61, 0x06, 0x14, 0x17, 0x6e, 0x0b, 0x42, 0x5d, 0x14, 0xa1, 0x2d, 0x2e, 0xdc, 0x0c, 0xd6, 0x1c,
-	0xda, 0x40, 0xd3, 0x94, 0x49, 0x5a, 0xc6, 0x3e, 0x85, 0xcf, 0xe0, 0xd3, 0xb8, 0xec, 0xd2, 0xa5,
-	0xcc, 0xbc, 0x88, 0x4c, 0x66, 0xc4, 0xc2, 0xb8, 0x3b, 0xf9, 0xbe, 0xf3, 0x27, 0x81, 0x1f, 0xb8,
-	0xc5, 0x85, 0xc0, 0x58, 0xc9, 0x85, 0x0d, 0x15, 0xaa, 0xa5, 0xd6, 0xf3, 0xd0, 0xbe, 0x2e, 0xd1,
-	0x04, 0xcb, 0x58, 0x5b, 0xcd, 0xd8, 0xaf, 0x0f, 0x4a, 0xdf, 0x69, 0x03, 0x1d, 0x27, 0x86, 0x1d,
-	0x01, 0xb5, 0x89, 0xf1, 0xc9, 0x19, 0xed, 0xb6, 0x86, 0xf9, 0xd8, 0xb1, 0xd0, 0x18, 0xa0, 0x31,
-	0xcf, 0x53, 0x64, 0x97, 0x3f, 0x92, 0x74, 0x9b, 0x57, 0xed, 0xa0, 0x7a, 0x4b, 0x30, 0x4e, 0x4c,
-	0xdf, 0x73, 0x39, 0x76, 0x03, 0x0d, 0x85, 0xeb, 0x28, 0x0f, 0xfc, 0x73, 0x81, 0xe3, 0xbf, 0x02,
-	0x83, 0xbb, 0xc7, 0x22, 0x53, 0x57, 0xb8, 0x1e, 0x27, 0xa6, 0x57, 0x03, 0x6a, 0x56, 0xaa, 0xf3,
-	0x4e, 0xa0, 0x5e, 0xb8, 0xea, 0x97, 0xd8, 0x05, 0x1c, 0x0a, 0x34, 0x32, 0x46, 0x11, 0xcd, 0x50,
-	0x4e, 0x67, 0xd6, 0xbd, 0x40, 0x87, 0x07, 0x25, 0xed, 0x3b, 0xc8, 0x4e, 0x60, 0x7f, 0xb2, 0x5a,
-	0x88, 0x39, 0x46, 0x52, 0xf8, 0xd4, 0x6d, 0xec, 0x15, 0xe0, 0x5e, 0xb0, 0x73, 0x68, 0x95, 0x52,
-	0xc7, 0x02, 0x63, 0xff, 0xbf, 0xf3, 0xcd, 0x82, 0x3d, 0xe4, 0x88, 0x9d, 0x42, 0x79, 0x8c, 0x8c,
-	0xdc, 0xa0, 0x5f, 0x73, 0x1b, 0x50, 0xa0, 0x91, 0xdc, 0x60, 0x6f, 0xf4, 0x91, 0x72, 0xb2, 0x4d,
-	0x39, 0xf9, 0x4a, 0x39, 0x79, 0xcb, 0xb8, 0xb7, 0xcd, 0xb8, 0xf7, 0x99, 0x71, 0xef, 0xe9, 0x76,
-	0x2a, 0xed, 0x6c, 0x35, 0x09, 0x5e, 0xb4, 0x0a, 0x77, 0xca, 0xd8, 0x19, 0x5d, 0x13, 0x61, 0xb5,
-	0xa8, 0x49, 0xdd, 0x99, 0xeb, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0x27, 0x5a, 0xb5, 0x8a, 0xc5,
-	0x01, 0x00, 0x00,
+	// 322 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2b, 0x49, 0xcd, 0x4b,
+	0x49, 0x2d, 0xca, 0xcd, 0xcc, 0x2b, 0xd1, 0xcf, 0x4d, 0xcd, 0x2d, 0xc8, 0xcf, 0xcf, 0xd1, 0x2f,
+	0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x42, 0xc8, 0xeb, 0x41,
+	0xe5, 0x95, 0xc4, 0xb9, 0x98, 0x43, 0x2a, 0x8a, 0x85, 0x04, 0xb8, 0x98, 0x4b, 0x2a, 0x8a, 0x25,
+	0x18, 0x15, 0x98, 0x35, 0x78, 0x82, 0x40, 0x4c, 0xa5, 0x12, 0x2e, 0x76, 0xdf, 0xd4, 0xe2, 0xe2,
+	0xc4, 0xf4, 0x54, 0x21, 0x6d, 0x98, 0x24, 0xa3, 0x06, 0xb7, 0x91, 0xb8, 0x1e, 0xa6, 0x29, 0x7a,
+	0x21, 0x15, 0xc5, 0x1e, 0x0c, 0x60, 0x7d, 0x42, 0xa6, 0x5c, 0xec, 0xb9, 0xa9, 0x65, 0xf1, 0x20,
+	0x0d, 0x4c, 0x60, 0x0d, 0x52, 0xd8, 0x34, 0xf8, 0xba, 0x86, 0x41, 0xf4, 0xb0, 0xe5, 0xa6, 0x96,
+	0x85, 0x54, 0x14, 0x3b, 0xb1, 0x72, 0x31, 0x17, 0x97, 0xe6, 0x2a, 0x9d, 0x60, 0xe4, 0xe2, 0xf2,
+	0x75, 0x0d, 0x23, 0xcb, 0x66, 0x55, 0x2e, 0xbe, 0x94, 0xd4, 0xe2, 0xcc, 0xa2, 0xd4, 0x94, 0xf8,
+	0x8c, 0xd4, 0xcc, 0xf4, 0x8c, 0x12, 0xb0, 0x03, 0x98, 0x83, 0x78, 0xa1, 0xa2, 0x1e, 0x60, 0x41,
+	0x21, 0x69, 0x2e, 0xce, 0xa4, 0xd2, 0xbc, 0x94, 0x9c, 0xd4, 0xf8, 0xcc, 0x14, 0x09, 0x66, 0xb0,
+	0x0a, 0x0e, 0x88, 0x80, 0x67, 0x8a, 0x90, 0x22, 0x17, 0x0f, 0x54, 0x32, 0xbf, 0x28, 0x25, 0xb5,
+	0x48, 0x82, 0x05, 0x2c, 0xcf, 0x0d, 0x11, 0xf3, 0x07, 0x09, 0x09, 0xc9, 0x73, 0x41, 0xb9, 0xf1,
+	0xc5, 0x99, 0x55, 0xa9, 0x12, 0xac, 0x60, 0x15, 0x5c, 0x10, 0xa1, 0xe0, 0xcc, 0xaa, 0x54, 0x98,
+	0x57, 0x16, 0x31, 0x72, 0xb1, 0x41, 0xbc, 0x89, 0x19, 0xba, 0x83, 0xc6, 0xad, 0xc1, 0x27, 0x1e,
+	0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17,
+	0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65, 0x99, 0x9e, 0x59, 0x92, 0x51, 0x9a, 0xa4,
+	0x97, 0x9c, 0x9f, 0xab, 0x8f, 0x94, 0xae, 0x90, 0x98, 0xe0, 0x44, 0xa5, 0x8f, 0x99, 0xe6, 0x92,
+	0xd8, 0xc0, 0x32, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0xee, 0xea, 0x3f, 0x1a, 0x90, 0x02,
+	0x00, 0x00,
 }
 
 func (m *Txs) Marshal() (dAtA []byte, err error) {
@@ -363,6 +470,79 @@ func (m *Message_MevTxs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		}
 		i--
 		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *MEVMessage) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MEVMessage) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MEVMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.BundleSize != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleSize))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.BundleOrder != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleOrder))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.BundleId != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleId))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.DesiredHeight != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.DesiredHeight))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Sum != nil {
+		{
+			size := m.Sum.Size()
+			i -= size
+			if _, err := m.Sum.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MEVMessage_Txs) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MEVMessage_Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Txs != nil {
+		{
+			size, err := m.Txs.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -476,6 +656,42 @@ func (m *Message_MevTxs) Size() (n int) {
 	_ = l
 	if m.MevTxs != nil {
 		l = m.MevTxs.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *MEVMessage) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Sum != nil {
+		n += m.Sum.Size()
+	}
+	if m.DesiredHeight != 0 {
+		n += 1 + sovTypes(uint64(m.DesiredHeight))
+	}
+	if m.BundleId != 0 {
+		n += 1 + sovTypes(uint64(m.BundleId))
+	}
+	if m.BundleOrder != 0 {
+		n += 1 + sovTypes(uint64(m.BundleOrder))
+	}
+	if m.BundleSize != 0 {
+		n += 1 + sovTypes(uint64(m.BundleSize))
+	}
+	return n
+}
+
+func (m *MEVMessage_Txs) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Txs != nil {
+		l = m.Txs.Size()
 		n += 1 + l + sovTypes(uint64(l))
 	}
 	return n
@@ -694,6 +910,167 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 			}
 			m.Sum = &Message_MevTxs{v}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MEVMessage) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MEVMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MEVMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Txs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &Txs{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &MEVMessage_Txs{v}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DesiredHeight", wireType)
+			}
+			m.DesiredHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DesiredHeight |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleId", wireType)
+			}
+			m.BundleId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleId |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleOrder", wireType)
+			}
+			m.BundleOrder = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleOrder |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleSize", wireType)
+			}
+			m.BundleSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleSize |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTypes(dAtA[iNdEx:])

--- a/proto/tendermint/mempool/types.pb.go
+++ b/proto/tendermint/mempool/types.pb.go
@@ -68,7 +68,9 @@ func (m *Txs) GetTxs() [][]byte {
 
 type Message struct {
 	// Types that are valid to be assigned to Sum:
+	//
 	//	*Message_Txs
+	//	*Message_MevTxs
 	Sum isMessage_Sum `protobuf_oneof:"sum"`
 }
 
@@ -114,8 +116,12 @@ type isMessage_Sum interface {
 type Message_Txs struct {
 	Txs *Txs `protobuf:"bytes,1,opt,name=txs,proto3,oneof" json:"txs,omitempty"`
 }
+type Message_MevTxs struct {
+	MevTxs *MEVTxs `protobuf:"bytes,2,opt,name=mev_txs,json=mevTxs,proto3,oneof" json:"mev_txs,omitempty"`
+}
 
-func (*Message_Txs) isMessage_Sum() {}
+func (*Message_Txs) isMessage_Sum()    {}
+func (*Message_MevTxs) isMessage_Sum() {}
 
 func (m *Message) GetSum() isMessage_Sum {
 	if m != nil {
@@ -131,34 +137,127 @@ func (m *Message) GetTxs() *Txs {
 	return nil
 }
 
+func (m *Message) GetMevTxs() *MEVTxs {
+	if x, ok := m.GetSum().(*Message_MevTxs); ok {
+		return x.MevTxs
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*Message) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
 		(*Message_Txs)(nil),
+		(*Message_MevTxs)(nil),
 	}
+}
+
+type MEVTxs struct {
+	Txs           [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
+	DesiredHeight int64    `protobuf:"varint,2,opt,name=desired_height,json=desiredHeight,proto3" json:"desired_height,omitempty"`
+	BundleId      int64    `protobuf:"varint,3,opt,name=bundle_id,json=bundleId,proto3" json:"bundle_id,omitempty"`
+	BundleOrder   int64    `protobuf:"varint,4,opt,name=bundle_order,json=bundleOrder,proto3" json:"bundle_order,omitempty"`
+	BundleSize    int64    `protobuf:"varint,5,opt,name=bundle_size,json=bundleSize,proto3" json:"bundle_size,omitempty"`
+}
+
+func (m *MEVTxs) Reset()         { *m = MEVTxs{} }
+func (m *MEVTxs) String() string { return proto.CompactTextString(m) }
+func (*MEVTxs) ProtoMessage()    {}
+func (*MEVTxs) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2af51926fdbcbc05, []int{2}
+}
+func (m *MEVTxs) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MEVTxs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MEVTxs.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MEVTxs) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MEVTxs.Merge(m, src)
+}
+func (m *MEVTxs) XXX_Size() int {
+	return m.Size()
+}
+func (m *MEVTxs) XXX_DiscardUnknown() {
+	xxx_messageInfo_MEVTxs.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MEVTxs proto.InternalMessageInfo
+
+func (m *MEVTxs) GetTxs() [][]byte {
+	if m != nil {
+		return m.Txs
+	}
+	return nil
+}
+
+func (m *MEVTxs) GetDesiredHeight() int64 {
+	if m != nil {
+		return m.DesiredHeight
+	}
+	return 0
+}
+
+func (m *MEVTxs) GetBundleId() int64 {
+	if m != nil {
+		return m.BundleId
+	}
+	return 0
+}
+
+func (m *MEVTxs) GetBundleOrder() int64 {
+	if m != nil {
+		return m.BundleOrder
+	}
+	return 0
+}
+
+func (m *MEVTxs) GetBundleSize() int64 {
+	if m != nil {
+		return m.BundleSize
+	}
+	return 0
 }
 
 func init() {
 	proto.RegisterType((*Txs)(nil), "tendermint.mempool.Txs")
 	proto.RegisterType((*Message)(nil), "tendermint.mempool.Message")
+	proto.RegisterType((*MEVTxs)(nil), "tendermint.mempool.MEVTxs")
 }
 
 func init() { proto.RegisterFile("tendermint/mempool/types.proto", fileDescriptor_2af51926fdbcbc05) }
 
 var fileDescriptor_2af51926fdbcbc05 = []byte{
-	// 179 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2b, 0x49, 0xcd, 0x4b,
-	0x49, 0x2d, 0xca, 0xcd, 0xcc, 0x2b, 0xd1, 0xcf, 0x4d, 0xcd, 0x2d, 0xc8, 0xcf, 0xcf, 0xd1, 0x2f,
-	0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x42, 0xc8, 0xeb, 0x41,
-	0xe5, 0x95, 0xc4, 0xb9, 0x98, 0x43, 0x2a, 0x8a, 0x85, 0x04, 0xb8, 0x98, 0x4b, 0x2a, 0x8a, 0x25,
-	0x18, 0x15, 0x98, 0x35, 0x78, 0x82, 0x40, 0x4c, 0x25, 0x5b, 0x2e, 0x76, 0xdf, 0xd4, 0xe2, 0xe2,
-	0xc4, 0xf4, 0x54, 0x21, 0x6d, 0x98, 0x24, 0xa3, 0x06, 0xb7, 0x91, 0xb8, 0x1e, 0xa6, 0x29, 0x7a,
-	0x21, 0x15, 0xc5, 0x1e, 0x0c, 0x60, 0x7d, 0x4e, 0xac, 0x5c, 0xcc, 0xc5, 0xa5, 0xb9, 0x4e, 0xc1,
-	0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72,
-	0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65, 0x99, 0x9e, 0x59, 0x92, 0x51,
-	0x9a, 0xa4, 0x97, 0x9c, 0x9f, 0xab, 0x8f, 0xe4, 0x60, 0x24, 0x26, 0xd8, 0xb5, 0xfa, 0x98, 0x9e,
-	0x49, 0x62, 0x03, 0xcb, 0x18, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0xca, 0xc3, 0xa0, 0xfc, 0xe9,
-	0x00, 0x00, 0x00,
+	// 307 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xc1, 0x4a, 0x2b, 0x31,
+	0x14, 0x86, 0x27, 0x37, 0xb7, 0xad, 0x9e, 0x56, 0x91, 0x6c, 0x3a, 0x28, 0x44, 0x2d, 0x08, 0x05,
+	0x61, 0x06, 0x14, 0x17, 0x6e, 0x0b, 0x42, 0x5d, 0x14, 0xa1, 0x2d, 0x2e, 0xdc, 0x0c, 0xd6, 0x1c,
+	0xda, 0x40, 0xd3, 0x94, 0x49, 0x5a, 0xc6, 0x3e, 0x85, 0xcf, 0xe0, 0xd3, 0xb8, 0xec, 0xd2, 0xa5,
+	0xcc, 0xbc, 0x88, 0x4c, 0x66, 0xc4, 0xc2, 0xb8, 0x3b, 0xf9, 0xbe, 0xf3, 0x27, 0x81, 0x1f, 0xb8,
+	0xc5, 0x85, 0xc0, 0x58, 0xc9, 0x85, 0x0d, 0x15, 0xaa, 0xa5, 0xd6, 0xf3, 0xd0, 0xbe, 0x2e, 0xd1,
+	0x04, 0xcb, 0x58, 0x5b, 0xcd, 0xd8, 0xaf, 0x0f, 0x4a, 0xdf, 0x69, 0x03, 0x1d, 0x27, 0x86, 0x1d,
+	0x01, 0xb5, 0x89, 0xf1, 0xc9, 0x19, 0xed, 0xb6, 0x86, 0xf9, 0xd8, 0xb1, 0xd0, 0x18, 0xa0, 0x31,
+	0xcf, 0x53, 0x64, 0x97, 0x3f, 0x92, 0x74, 0x9b, 0x57, 0xed, 0xa0, 0x7a, 0x4b, 0x30, 0x4e, 0x4c,
+	0xdf, 0x73, 0x39, 0x76, 0x03, 0x0d, 0x85, 0xeb, 0x28, 0x0f, 0xfc, 0x73, 0x81, 0xe3, 0xbf, 0x02,
+	0x83, 0xbb, 0xc7, 0x22, 0x53, 0x57, 0xb8, 0x1e, 0x27, 0xa6, 0x57, 0x03, 0x6a, 0x56, 0xaa, 0xf3,
+	0x4e, 0xa0, 0x5e, 0xb8, 0xea, 0x97, 0xd8, 0x05, 0x1c, 0x0a, 0x34, 0x32, 0x46, 0x11, 0xcd, 0x50,
+	0x4e, 0x67, 0xd6, 0xbd, 0x40, 0x87, 0x07, 0x25, 0xed, 0x3b, 0xc8, 0x4e, 0x60, 0x7f, 0xb2, 0x5a,
+	0x88, 0x39, 0x46, 0x52, 0xf8, 0xd4, 0x6d, 0xec, 0x15, 0xe0, 0x5e, 0xb0, 0x73, 0x68, 0x95, 0x52,
+	0xc7, 0x02, 0x63, 0xff, 0xbf, 0xf3, 0xcd, 0x82, 0x3d, 0xe4, 0x88, 0x9d, 0x42, 0x79, 0x8c, 0x8c,
+	0xdc, 0xa0, 0x5f, 0x73, 0x1b, 0x50, 0xa0, 0x91, 0xdc, 0x60, 0x6f, 0xf4, 0x91, 0x72, 0xb2, 0x4d,
+	0x39, 0xf9, 0x4a, 0x39, 0x79, 0xcb, 0xb8, 0xb7, 0xcd, 0xb8, 0xf7, 0x99, 0x71, 0xef, 0xe9, 0x76,
+	0x2a, 0xed, 0x6c, 0x35, 0x09, 0x5e, 0xb4, 0x0a, 0x77, 0xca, 0xd8, 0x19, 0x5d, 0x13, 0x61, 0xb5,
+	0xa8, 0x49, 0xdd, 0x99, 0xeb, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0x27, 0x5a, 0xb5, 0x8a, 0xc5,
+	0x01, 0x00, 0x00,
 }
 
 func (m *Txs) Marshal() (dAtA []byte, err error) {
@@ -246,6 +345,79 @@ func (m *Message_Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+func (m *Message_MevTxs) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_MevTxs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.MevTxs != nil {
+		{
+			size, err := m.MevTxs.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *MEVTxs) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MEVTxs) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MEVTxs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.BundleSize != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleSize))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.BundleOrder != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleOrder))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.BundleId != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BundleId))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.DesiredHeight != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.DesiredHeight))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Txs) > 0 {
+		for iNdEx := len(m.Txs) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Txs[iNdEx])
+			copy(dAtA[i:], m.Txs[iNdEx])
+			i = encodeVarintTypes(dAtA, i, uint64(len(m.Txs[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -293,6 +465,44 @@ func (m *Message_Txs) Size() (n int) {
 	if m.Txs != nil {
 		l = m.Txs.Size()
 		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Message_MevTxs) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MevTxs != nil {
+		l = m.MevTxs.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *MEVTxs) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Txs) > 0 {
+		for _, b := range m.Txs {
+			l = len(b)
+			n += 1 + l + sovTypes(uint64(l))
+		}
+	}
+	if m.DesiredHeight != 0 {
+		n += 1 + sovTypes(uint64(m.DesiredHeight))
+	}
+	if m.BundleId != 0 {
+		n += 1 + sovTypes(uint64(m.BundleId))
+	}
+	if m.BundleOrder != 0 {
+		n += 1 + sovTypes(uint64(m.BundleOrder))
+	}
+	if m.BundleSize != 0 {
+		n += 1 + sovTypes(uint64(m.BundleSize))
 	}
 	return n
 }
@@ -449,6 +659,199 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 			}
 			m.Sum = &Message_Txs{v}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MevTxs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &MEVTxs{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &Message_MevTxs{v}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MEVTxs) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MEVTxs: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MEVTxs: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Txs", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Txs = append(m.Txs, make([]byte, postIndex-iNdEx))
+			copy(m.Txs[len(m.Txs)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DesiredHeight", wireType)
+			}
+			m.DesiredHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DesiredHeight |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleId", wireType)
+			}
+			m.BundleId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleId |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleOrder", wireType)
+			}
+			m.BundleOrder = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleOrder |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BundleSize", wireType)
+			}
+			m.BundleSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BundleSize |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTypes(dAtA[iNdEx:])

--- a/proto/tendermint/mempool/types.proto
+++ b/proto/tendermint/mempool/types.proto
@@ -14,6 +14,16 @@ message Message {
   }
 }
 
+message MEVMessage {
+  oneof sum {
+    Txs txs = 1;
+  }
+  int64 desired_height = 2;
+  int64 bundle_id = 3;
+  int64 bundle_order = 4;
+  int64 bundle_size = 5;
+}
+
 message MEVTxs {
   repeated bytes txs = 1;
   int64 desired_height = 2;

--- a/proto/tendermint/mempool/types.proto
+++ b/proto/tendermint/mempool/types.proto
@@ -10,5 +10,14 @@ message Txs {
 message Message {
   oneof sum {
     Txs txs = 1;
+    MEVTxs mev_txs = 2;
   }
+}
+
+message MEVTxs {
+  repeated bytes txs = 1;
+  int64 desired_height = 2;
+  int64 bundle_id = 3;
+  int64 bundle_order = 4;
+  int64 bundle_size = 5;
 }

--- a/proto/tendermint/p2p/conn.pb.go
+++ b/proto/tendermint/p2p/conn.pb.go
@@ -158,6 +158,7 @@ func (m *PacketMsg) GetData() []byte {
 
 type Packet struct {
 	// Types that are valid to be assigned to Sum:
+	//
 	//	*Packet_PacketPing
 	//	*Packet_PacketPong
 	//	*Packet_PacketMsg

--- a/proto/tendermint/statesync/types.pb.go
+++ b/proto/tendermint/statesync/types.pb.go
@@ -24,6 +24,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Message struct {
 	// Types that are valid to be assigned to Sum:
+	//
 	//	*Message_SnapshotsRequest
 	//	*Message_SnapshotsResponse
 	//	*Message_ChunkRequest

--- a/proxy/mocks/app_conn_consensus.go
+++ b/proxy/mocks/app_conn_consensus.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	abcicli "github.com/tendermint/tendermint/abci/client"
 
 	types "github.com/tendermint/tendermint/abci/types"
@@ -142,13 +141,13 @@ func (_m *AppConnConsensus) SetResponseCallback(_a0 abcicli.Callback) {
 	_m.Called(_a0)
 }
 
-type NewAppConnConsensusT interface {
+type mockConstructorTestingTNewAppConnConsensus interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAppConnConsensus creates a new instance of AppConnConsensus. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnConsensus(t NewAppConnConsensusT) *AppConnConsensus {
+func NewAppConnConsensus(t mockConstructorTestingTNewAppConnConsensus) *AppConnConsensus {
 	mock := &AppConnConsensus{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_mempool.go
+++ b/proxy/mocks/app_conn_mempool.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	abcicli "github.com/tendermint/tendermint/abci/client"
 
 	types "github.com/tendermint/tendermint/abci/types"
@@ -103,13 +102,13 @@ func (_m *AppConnMempool) SetResponseCallback(_a0 abcicli.Callback) {
 	_m.Called(_a0)
 }
 
-type NewAppConnMempoolT interface {
+type mockConstructorTestingTNewAppConnMempool interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAppConnMempool creates a new instance of AppConnMempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnMempool(t NewAppConnMempoolT) *AppConnMempool {
+func NewAppConnMempool(t mockConstructorTestingTNewAppConnMempool) *AppConnMempool {
 	mock := &AppConnMempool{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_query.go
+++ b/proxy/mocks/app_conn_query.go
@@ -96,13 +96,13 @@ func (_m *AppConnQuery) QuerySync(_a0 types.RequestQuery) (*types.ResponseQuery,
 	return r0, r1
 }
 
-type NewAppConnQueryT interface {
+type mockConstructorTestingTNewAppConnQuery interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAppConnQuery creates a new instance of AppConnQuery. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnQuery(t NewAppConnQueryT) *AppConnQuery {
+func NewAppConnQuery(t mockConstructorTestingTNewAppConnQuery) *AppConnQuery {
 	mock := &AppConnQuery{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_snapshot.go
+++ b/proxy/mocks/app_conn_snapshot.go
@@ -119,13 +119,13 @@ func (_m *AppConnSnapshot) OfferSnapshotSync(_a0 types.RequestOfferSnapshot) (*t
 	return r0, r1
 }
 
-type NewAppConnSnapshotT interface {
+type mockConstructorTestingTNewAppConnSnapshot interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAppConnSnapshot creates a new instance of AppConnSnapshot. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnSnapshot(t NewAppConnSnapshotT) *AppConnSnapshot {
+func NewAppConnSnapshot(t mockConstructorTestingTNewAppConnSnapshot) *AppConnSnapshot {
 	mock := &AppConnSnapshot{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/client_creator.go
+++ b/proxy/mocks/client_creator.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	abcicli "github.com/tendermint/tendermint/abci/client"
 )
 

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -93,10 +93,12 @@ type Environment struct {
 	ConsensusReactor *consensus.Reactor
 	EventBus         *types.EventBus // thread safe
 	Mempool          mempl.Mempool
+	Sidecar          mempl.PriorityTxSidecar
 
 	Logger log.Logger
 
-	Config cfg.RPCConfig
+	Config        cfg.RPCConfig
+	SidecarConfig cfg.SidecarConfig
 
 	// cache of chunked genesis data.
 	genChunks []string

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
@@ -51,6 +52,19 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 		votingPower = val.VotingPower
 	}
 
+	var (
+		isPeeredWithRelayer      bool
+		lastReceivedBundleHeight int64
+	)
+
+	if relayer := env.SidecarConfig.RelayerPeerString; relayer != "" {
+		isPeeredWithRelayer = env.P2PPeers.Peers().Has(p2p.ID(strings.Split(relayer, "@")[0]))
+	}
+
+	if env.Sidecar != nil {
+		lastReceivedBundleHeight = env.Sidecar.GetLastBundleHeight()
+	}
+
 	result := &ctypes.ResultStatus{
 		NodeInfo: env.P2PTransport.NodeInfo().(p2p.DefaultNodeInfo),
 		SyncInfo: ctypes.SyncInfo{
@@ -68,6 +82,10 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			Address:     env.PubKey.Address(),
 			PubKey:      env.PubKey,
 			VotingPower: votingPower,
+		},
+		MevInfo: ctypes.MevInfo{
+			IsPeeredWithRelayer:      isPeeredWithRelayer,
+			LastReceivedBundleHeight: lastReceivedBundleHeight,
 		},
 	}
 

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -91,11 +91,17 @@ type ValidatorInfo struct {
 	VotingPower int64          `json:"voting_power"`
 }
 
+type MevInfo struct {
+	IsPeeredWithRelayer      bool  `json:"is_peered_with_relayer"`
+	LastReceivedBundleHeight int64 `json:"last_received_bundle_height"`
+}
+
 // Node Status
 type ResultStatus struct {
 	NodeInfo      p2p.DefaultNodeInfo `json:"node_info"`
 	SyncInfo      SyncInfo            `json:"sync_info"`
 	ValidatorInfo ValidatorInfo       `json:"validator_info"`
+	MevInfo       MevInfo             `json:"mev_info"`
 }
 
 // Is TxIndexing enabled

--- a/state/execution.go
+++ b/state/execution.go
@@ -36,6 +36,7 @@ type BlockExecutor struct {
 	// and update both with block results after commit.
 	mempool mempl.Mempool
 	evpool  EvidencePool
+	sidecar mempl.PriorityTxSidecar
 
 	logger log.Logger
 
@@ -58,6 +59,7 @@ func NewBlockExecutor(
 	proxyApp proxy.AppConnConsensus,
 	mempool mempl.Mempool,
 	evpool EvidencePool,
+	sidecar mempl.PriorityTxSidecar,
 	options ...BlockExecutorOption,
 ) *BlockExecutor {
 	res := &BlockExecutor{
@@ -66,6 +68,7 @@ func NewBlockExecutor(
 		eventBus: types.NopEventBus{},
 		mempool:  mempool,
 		evpool:   evpool,
+		sidecar:  sidecar,
 		logger:   logger,
 		metrics:  NopMetrics(),
 	}
@@ -105,7 +108,13 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
-	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
+	sidecarTxs := make([]*mempl.MempoolTx, 0)
+	if blockExec.sidecar != nil {
+		sidecarTxs = blockExec.sidecar.ReapMaxTxs()
+	} else {
+		fmt.Println("Sidecar is nil, not reaping")
+	}
+	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas, sidecarTxs)
 
 	return state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 }
@@ -239,6 +248,19 @@ func (blockExec *BlockExecutor) Commit(
 		"app_hash", fmt.Sprintf("%X", res.Data),
 	)
 
+	if blockExec.sidecar != nil {
+		// update sidecar mempool
+		err = blockExec.sidecar.Update(
+			block.Height,
+			block.Txs,
+			deliverTxResponses,
+		)
+		if err != nil {
+			blockExec.logger.Error("error while updating sidecar", "err", err)
+			return nil, 0, err
+		}
+	}
+
 	// Update mempool.
 	err = blockExec.mempool.Update(
 		block.Height,
@@ -247,6 +269,10 @@ func (blockExec *BlockExecutor) Commit(
 		TxPreCheck(state),
 		TxPostCheck(state),
 	)
+	if err != nil {
+		blockExec.logger.Error("error while updating mempool", "err", err)
+		return nil, 0, err
+	}
 
 	return res.Data, res.RetainHeight, err
 }

--- a/state/execution.go
+++ b/state/execution.go
@@ -108,13 +108,14 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
-	sidecarTxs := make([]*mempl.MempoolTx, 0)
+	var sidecarTxs types.ReapedTxs
 	if blockExec.sidecar != nil {
 		sidecarTxs = blockExec.sidecar.ReapMaxTxs()
 	} else {
 		fmt.Println("Sidecar is nil, not reaping")
 	}
-	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas, sidecarTxs)
+	memplTxs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
+	txs := mempl.CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, maxDataBytes, maxGas)
 
 	return state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 }

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -46,7 +46,7 @@ func TestApplyBlock(t *testing.T) {
 	})
 
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
-		mmock.Mempool{}, sm.EmptyEvidencePool{})
+		mmock.Mempool{}, sm.EmptyEvidencePool{}, mmock.PriorityTxSidecar{})
 
 	block := makeBlock(state, 1)
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
@@ -205,7 +205,7 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 	evpool.On("CheckEvidence", mock.AnythingOfType("types.EvidenceList")).Return(nil)
 
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
-		mmock.Mempool{}, evpool)
+		mmock.Mempool{}, evpool, mmock.PriorityTxSidecar{})
 
 	block := makeBlock(state, 1)
 	block.Evidence = types.EvidenceData{Evidence: ev}
@@ -370,6 +370,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 		proxyApp.Consensus(),
 		mmock.Mempool{},
 		sm.EmptyEvidencePool{},
+		mmock.PriorityTxSidecar{},
 	)
 
 	eventBus := types.NewEventBus()
@@ -442,6 +443,7 @@ func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 		proxyApp.Consensus(),
 		mmock.Mempool{},
 		sm.EmptyEvidencePool{},
+		mmock.PriorityTxSidecar{},
 	)
 
 	block := makeBlock(state, 1)

--- a/state/mocks/block_store.go
+++ b/state/mocks/block_store.go
@@ -193,13 +193,13 @@ func (_m *BlockStore) Size() int64 {
 	return r0
 }
 
-type NewBlockStoreT interface {
+type mockConstructorTestingTNewBlockStore interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBlockStore(t NewBlockStoreT) *BlockStore {
+func NewBlockStore(t mockConstructorTestingTNewBlockStore) *BlockStore {
 	mock := &BlockStore{}
 	mock.Mock.Test(t)
 

--- a/state/mocks/evidence_pool.go
+++ b/state/mocks/evidence_pool.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	state "github.com/tendermint/tendermint/state"
 
 	types "github.com/tendermint/tendermint/types"
@@ -71,13 +70,13 @@ func (_m *EvidencePool) Update(_a0 state.State, _a1 types.EvidenceList) {
 	_m.Called(_a0, _a1)
 }
 
-type NewEvidencePoolT interface {
+type mockConstructorTestingTNewEvidencePool interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewEvidencePool creates a new instance of EvidencePool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewEvidencePool(t NewEvidencePoolT) *EvidencePool {
+func NewEvidencePool(t mockConstructorTestingTNewEvidencePool) *EvidencePool {
 	mock := &EvidencePool{}
 	mock.Mock.Test(t)
 

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
-
 	state "github.com/tendermint/tendermint/state"
 
 	tendermintstate "github.com/tendermint/tendermint/proto/tendermint/state"
@@ -242,13 +241,13 @@ func (_m *Store) SaveABCIResponses(_a0 int64, _a1 *tendermintstate.ABCIResponses
 	return r0
 }
 
-type NewStoreT interface {
+type mockConstructorTestingTNewStore interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewStore creates a new instance of Store. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewStore(t NewStoreT) *Store {
+func NewStore(t mockConstructorTestingTNewStore) *Store {
 	mock := &Store{}
 	mock.Mock.Test(t)
 

--- a/state/txindex/mocks/tx_indexer.go
+++ b/state/txindex/mocks/tx_indexer.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	mock "github.com/stretchr/testify/mock"
-
 	query "github.com/tendermint/tendermint/libs/pubsub/query"
 
 	txindex "github.com/tendermint/tendermint/state/txindex"

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -37,6 +37,7 @@ func TestValidateBlockHeader(t *testing.T) {
 		proxyApp.Consensus(),
 		memmock.Mempool{},
 		sm.EmptyEvidencePool{},
+		memmock.PriorityTxSidecar{},
 	)
 	lastCommit := types.NewCommit(0, 0, types.BlockID{}, nil)
 
@@ -110,6 +111,7 @@ func TestValidateBlockCommit(t *testing.T) {
 		proxyApp.Consensus(),
 		memmock.Mempool{},
 		sm.EmptyEvidencePool{},
+		memmock.PriorityTxSidecar{},
 	)
 	lastCommit := types.NewCommit(0, 0, types.BlockID{}, nil)
 	wrongSigsCommit := types.NewCommit(1, 0, types.BlockID{}, nil)
@@ -235,6 +237,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 		proxyApp.Consensus(),
 		memmock.Mempool{},
 		evpool,
+		memmock.PriorityTxSidecar{},
 	)
 	lastCommit := types.NewCommit(0, 0, types.BlockID{}, nil)
 

--- a/statesync/mocks/state_provider.go
+++ b/statesync/mocks/state_provider.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	mock "github.com/stretchr/testify/mock"
-
 	state "github.com/tendermint/tendermint/state"
 
 	types "github.com/tendermint/tendermint/types"
@@ -84,13 +83,13 @@ func (_m *StateProvider) State(ctx context.Context, height uint64) (state.State,
 	return r0, r1
 }
 
-type NewStateProviderT interface {
+type mockConstructorTestingTNewStateProvider interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewStateProvider creates a new instance of StateProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewStateProvider(t NewStateProviderT) *StateProvider {
+func NewStateProvider(t mockConstructorTestingTNewStateProvider) *StateProvider {
 	mock := &StateProvider{}
 	mock.Mock.Test(t)
 

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -1,3 +1,4 @@
+// nolint: gosec
 package main
 
 import (

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -1,4 +1,4 @@
-// nolint: gosec
+//nolint: gosec
 package main
 
 import (

--- a/test/fuzz/p2p/addrbook/fuzz.go
+++ b/test/fuzz/p2p/addrbook/fuzz.go
@@ -1,3 +1,4 @@
+// nolint: gosec
 package addr
 
 import (

--- a/test/fuzz/p2p/addrbook/fuzz.go
+++ b/test/fuzz/p2p/addrbook/fuzz.go
@@ -1,4 +1,3 @@
-// nolint: gosec
 package addr
 
 import (

--- a/test/fuzz/p2p/addrbook/init-corpus/main.go
+++ b/test/fuzz/p2p/addrbook/init-corpus/main.go
@@ -1,3 +1,4 @@
+// nolint: gosec
 package main
 
 import (

--- a/test/fuzz/p2p/pex/init-corpus/main.go
+++ b/test/fuzz/p2p/pex/init-corpus/main.go
@@ -1,3 +1,4 @@
+// nolint: gosec
 package main
 
 import (

--- a/test/fuzz/p2p/pex/init-corpus/main.go
+++ b/test/fuzz/p2p/pex/init-corpus/main.go
@@ -1,4 +1,4 @@
-// nolint: gosec
+//nolint: gosec
 package main
 
 import (

--- a/test/fuzz/p2p/pex/reactor_receive.go
+++ b/test/fuzz/p2p/pex/reactor_receive.go
@@ -76,6 +76,7 @@ func (fp *fuzzPeer) RemoteAddr() net.Addr {
 }
 func (fp *fuzzPeer) IsOutbound() bool                    { return false }
 func (fp *fuzzPeer) IsPersistent() bool                  { return false }
+func (fp *fuzzPeer) IsSidecarPeer() bool                 { return false }
 func (fp *fuzzPeer) CloseConn() error                    { return nil }
 func (fp *fuzzPeer) NodeInfo() p2p.NodeInfo              { return defaultNodeInfo }
 func (fp *fuzzPeer) Status() p2p.ConnectionStatus        { var cs p2p.ConnectionStatus; return cs }

--- a/test/fuzz/p2p/secret_connection/init-corpus/main.go
+++ b/test/fuzz/p2p/secret_connection/init-corpus/main.go
@@ -1,3 +1,4 @@
+// nolint: gosec
 package main
 
 import (

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -497,7 +497,8 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 
 	// Use stubs for both mempool and evidence pool since no transactions nor
 	// evidence are needed here - block already exists.
-	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp, emptyMempool{}, sm.EmptyEvidencePool{})
+	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp,
+		emptyMempool{}, sm.EmptyEvidencePool{}, emptySidecar{})
 	blockExec.SetEventBus(h.eventBus)
 
 	var err error

--- a/test/maverick/consensus/replay_file.go
+++ b/test/maverick/consensus/replay_file.go
@@ -330,8 +330,8 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 		tmos.Exit(fmt.Sprintf("Error on handshake: %v", err))
 	}
 
-	mempool, evpool := emptyMempool{}, sm.EmptyEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	mempool, evpool, sidecar := emptyMempool{}, sm.EmptyEvidencePool{}, emptySidecar{}
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, sidecar)
 
 	consensusState := NewState(csConfig, state.Copy(), blockExec,
 		blockStore, mempool, evpool, map[int64]Misbehavior{})

--- a/test/maverick/consensus/replay_stubs.go
+++ b/test/maverick/consensus/replay_stubs.go
@@ -22,9 +22,11 @@ func (emptyMempool) SizeBytes() int64 { return 0 }
 func (emptyMempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) error {
 	return nil
 }
-func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error   { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (emptyMempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
+func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error { return nil }
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
+	return types.Txs{}
+}
+func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
 	_ int64,
 	_ types.Txs,
@@ -45,6 +47,39 @@ func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }
 
 func (emptyMempool) InitWAL() error { return nil }
 func (emptyMempool) CloseWAL()      {}
+
+//-----------------------------------------------------------------------------
+
+type emptySidecar struct{}
+
+var _ mempl.PriorityTxSidecar = emptySidecar{}
+
+func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
+func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+
+func (emptySidecar) Lock()   {}
+func (emptySidecar) Unlock() {}
+
+func (emptySidecar) HeightForFiringAuction() int64 { return 0 }
+
+func (emptySidecar) TxsWaitChan() <-chan struct{} { return nil }
+
+func (emptySidecar) Flush() {}
+func (emptySidecar) Update(
+	blockHeight int64,
+	blockTxs types.Txs,
+	_ []*abci.ResponseDeliverTx,
+) error {
+	return nil
+}
+
+func (emptySidecar) TxsAvailable() <-chan struct{} { return make(chan struct{}) }
+func (emptySidecar) EnableTxsAvailable()           {}
+
+func (emptySidecar) Size() int       { return 0 }
+func (emptySidecar) TxsBytes() int64 { return 0 }
+
+func (emptySidecar) GetLastBundleHeight() int64 { return 0 }
 
 //-----------------------------------------------------------------------------
 // mockProxyApp uses ABCIResponses to give the right results.

--- a/test/maverick/consensus/replay_stubs.go
+++ b/test/maverick/consensus/replay_stubs.go
@@ -23,8 +23,8 @@ func (emptyMempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) 
 	return nil
 }
 func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64, _ []*mempl.MempoolTx) types.Txs {
-	return types.Txs{}
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.ReapedTxs {
+	return types.ReapedTxs{}
 }
 func (emptyMempool) ReapMaxTxs(n int) types.Txs { return types.Txs{} }
 func (emptyMempool) Update(
@@ -55,7 +55,7 @@ type emptySidecar struct{}
 var _ mempl.PriorityTxSidecar = emptySidecar{}
 
 func (emptySidecar) AddTx(_ types.Tx, _ mempl.TxInfo) error { return nil }
-func (emptySidecar) ReapMaxTxs() []*mempl.MempoolTx         { return []*mempl.MempoolTx{} }
+func (emptySidecar) ReapMaxTxs() types.ReapedTxs            { return types.ReapedTxs{} }
 
 func (emptySidecar) Lock()   {}
 func (emptySidecar) Unlock() {}

--- a/test/maverick/consensus/wal_generator.go
+++ b/test/maverick/consensus/wal_generator.go
@@ -86,7 +86,8 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	})
 	mempool := emptyMempool{}
 	evpool := sm.EmptyEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
+		mempool, evpool, emptySidecar{})
 	consensusState := NewState(config.Consensus, state.Copy(),
 		blockExec, blockStore, mempool, evpool, map[int64]Misbehavior{})
 	consensusState.SetLogger(logger)

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -381,6 +381,11 @@ func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
 
 func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 	state sm.State, memplMetrics *mempl.Metrics, logger log.Logger) (p2p.Reactor, mempl.Mempool, mempl.PriorityTxSidecar) {
+	sidecar := mempl.NewCListSidecar(
+		state.LastBlockHeight,
+		logger,
+		memplMetrics,
+	)
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
@@ -397,12 +402,13 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 		reactor := mempoolv1.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return reactor, mp, nil
+		return reactor, mp, sidecar
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -415,12 +421,6 @@ func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy
 		)
 
 		mp.SetLogger(logger)
-
-		sidecar := mempoolv0.NewCListSidecar(
-			state.LastBlockHeight,
-			logger,
-			memplMetrics,
-		)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -379,9 +379,9 @@ func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
 	return bytes.Equal(pubKey.Address(), addr)
 }
 
-func createMempoolAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
-	state sm.State, memplMetrics *mempl.Metrics, logger log.Logger,
-) (p2p.Reactor, mempl.Mempool) {
+func createMempoolAndSidecarAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
+	state sm.State, memplMetrics *mempl.Metrics, logger log.Logger) (p2p.Reactor, mempl.Mempool, mempl.PriorityTxSidecar) {
+
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -402,7 +402,7 @@ func createMempoolAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 			mp.EnableTxsAvailable()
 		}
 
-		return reactor, mp
+		return reactor, mp, nil
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -415,20 +415,26 @@ func createMempoolAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 		)
 
 		mp.SetLogger(logger)
-		mp.SetLogger(logger)
+
+		sidecar := mempoolv0.NewCListSidecar(
+			state.LastBlockHeight,
+			logger,
+			memplMetrics,
+		)
 
 		reactor := mempoolv0.NewReactor(
 			config.Mempool,
 			mp,
+			sidecar,
 		)
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
 
-		return reactor, mp
+		return reactor, mp, sidecar
 
 	default:
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -593,7 +599,9 @@ func createSwitch(config *cfg.Config,
 ) *p2p.Switch {
 	sw := p2p.NewSwitch(
 		config.P2P,
+		make(p2p.SidecarPeers, 0),
 		transport,
+		"",
 		p2p.WithMetrics(p2pMetrics),
 		p2p.SwitchPeerFilters(peerFilters...),
 	)
@@ -808,7 +816,7 @@ func NewNode(config *cfg.Config,
 	csMetrics, p2pMetrics, memplMetrics, smMetrics := metricsProvider(genDoc.ChainID)
 
 	// Make MempoolReactor
-	mempoolReactor, mempool := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
+	mempoolReactor, mempool, sidecar := createMempoolAndSidecarAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
 
 	// Make Evidence Reactor
 	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateDB, blockStore, logger)
@@ -823,6 +831,7 @@ func NewNode(config *cfg.Config,
 		proxyApp.Consensus(),
 		mempool,
 		evidencePool,
+		sidecar,
 		sm.BlockExecutorWithMetrics(smMetrics),
 	)
 
@@ -1352,7 +1361,7 @@ func makeNodeInfo(
 		Channels: []byte{
 			bcChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
-			mempl.MempoolChannel,
+			mempl.MempoolChannel, mempl.SidecarChannel,
 			evidence.EvidenceChannel,
 			statesync.SnapshotChannel, statesync.ChunkChannel,
 		},

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -1361,7 +1361,7 @@ func makeNodeInfo(
 		Channels: []byte{
 			bcChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
-			mempl.MempoolChannel, mempl.SidecarChannel,
+			mempl.MempoolChannel, mempl.SidecarChannel, mempl.SidecarLegacyChannel,
 			evidence.EvidenceChannel,
 			statesync.SnapshotChannel, statesync.ChunkChannel,
 		},

--- a/types/tx.go
+++ b/types/tx.go
@@ -158,3 +158,9 @@ func ComputeProtoSizeForTxs(txs []Tx) int64 {
 	pdData := data.ToProto()
 	return int64(pdData.Size())
 }
+
+// Used for combining sidecar and mempl txes
+type ReapedTxs struct {
+	Txs        Txs
+	GasWanteds []int64
+}


### PR DESCRIPTION
## Description
This introduces support for v0.34.23 for nodes with v0 and v1 mempools. It also enables v0.34.23 nodes to be backwards compatible with v0.34.21 nodes on the same network to support the latest JUNO upgrade. So the validators who choose to, should be able to upgrade with no problems. 

### New gossiping protocol with "unwrappable" message
Created a new Message type in proto/tendermint/mempool, so that Message can be unwrapped into: 

* Txs (As normal) 
* MEVTxs (Which includes bundle metadata) 

This structure mimics other Wrappable / Unwrappable Message types throughout tendermint (e.g. see consensus protos), and doesn't interfere with the node's ability to gossip with non-mev tendermint nodes

Added a new channel for this message to be gossiped over

### Support for old gossiping protocol
* Added support for gossiping the legacy MEVMessage over original mev tendermint channel

* Broadcast sidecar tx initially tries using the new channel and new protobuf. If this fails, it tries the old channel and old protobuf

### To do 
- [x] Unit Test new gossiping receive and send functions
- [ ] Check test coverage failures
- [x] Test on internal testnet with one node running standard tendermint
- [x] Test on internal testnet with one node running v0.34.21-mev-tendermint and one running v0.34.23 mev-tendermint
- [x] Update the sentinel