### PR TITLE
[ENG-314] Safeguard reaps from invalid sidecars

### DIFF
--- a/mempool/mev_reap_test.go
+++ b/mempool/mev_reap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -22,14 +23,14 @@ func TestCombineSidecarAndMempoolTxs_SkipsSidecarTxsInMempoolReap(t *testing.T) 
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 50, 500)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 50, 500, log.TestingLogger())
 
 	// Assert that it only got reaped once
 	expectedTxs := types.Txs([]types.Tx{tx})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
 }
 
-func TestCombineSidecarAndMempoolTxs_SidecarHassMaxBytes(t *testing.T) {
+func TestCombineSidecarAndMempoolTxs_SidecarHasMaxBytes(t *testing.T) {
 	mplTx := makeTxWithNumBytes(t, 18)
 	scTx1 := makeTxWithNumBytes(t, 18)
 	scTx2 := makeTxWithNumBytes(t, 18)
@@ -44,7 +45,7 @@ func TestCombineSidecarAndMempoolTxs_SidecarHassMaxBytes(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 50)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 50, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
@@ -65,9 +66,51 @@ func TestCombineSidecarAndMempoolTxs_SidecarHasMaxGas(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 20)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 20, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2})
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarExceedsMaxBytes(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 30, 50, log.TestingLogger())
+
+	expectedTxs := memplTxs.Txs
+	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
+}
+
+func TestCombineSidecarAndMempoolTxs_SidecarExceedsMaxGas(t *testing.T) {
+	mplTx := makeTxWithNumBytes(t, 18)
+	scTx1 := makeTxWithNumBytes(t, 18)
+	scTx2 := makeTxWithNumBytes(t, 18)
+
+	memplTxs := types.ReapedTxs{
+		Txs:        []types.Tx{mplTx},
+		GasWanteds: []int64{10},
+	}
+	sidecarTxs := types.ReapedTxs{
+		Txs:        []types.Tx{scTx1, scTx2},
+		GasWanteds: []int64{10, 10},
+	}
+
+	// Combine
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 15, log.TestingLogger())
+
+	expectedTxs := memplTxs.Txs
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
 }
 
@@ -86,7 +129,7 @@ func TestCombineSidecarAndMempoolTxs_MempoolHasMaxBytes(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 40)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 40, 40, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
@@ -107,7 +150,7 @@ func TestCombineSidecarAndMempoolTxs_MempoolHasMaxGas(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 20)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 20, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{mplTx1, mplTx2})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
@@ -129,7 +172,7 @@ func TestCombineSidecarAndMempoolTxs_CombinedHasMaxBytes(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 60)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 60, 60, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)
@@ -151,7 +194,7 @@ func TestCombineSidecarAndMempoolTxs_CombinedHasMaxGas(t *testing.T) {
 	}
 
 	// Combine
-	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 30)
+	reapedTxs := CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, 100, 30, log.TestingLogger())
 
 	expectedTxs := types.Txs([]types.Tx{scTx1, scTx2, mplTx1})
 	assert.Equal(t, expectedTxs, reapedTxs, "Got %s, expected %s", reapedTxs, expectedTxs)

--- a/state/execution.go
+++ b/state/execution.go
@@ -112,10 +112,10 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	if blockExec.sidecar != nil {
 		sidecarTxs = blockExec.sidecar.ReapMaxTxs()
 	} else {
-		fmt.Println("Sidecar is nil, not reaping")
+		blockExec.logger.Info("[mev-tendermint]: Sidecar is nil, not reaping")
 	}
 	memplTxs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
-	txs := mempl.CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, maxDataBytes, maxGas)
+	txs := mempl.CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs, maxDataBytes, maxGas, blockExec.logger)
 
 	return state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 }


### PR DESCRIPTION
Using `mev_reap` can create blocks with partial sidecars if the sidecar exceeds gas or block limit, and empty blocks if the first sidecar tx that the sentinel sends exceeds the block max gas.
This falls back to the mempool txs if the sidecar ever exceeds max block bytes or gas.
Also switched some print statements to use loggers.