### PR TITLE
[ENG-319] Lookup IP every time we reconnect to relayer

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -903,7 +903,7 @@ func NewNode(config *cfg.Config,
 	}
 
 	if config.Sidecar.RelayerPeerString != "" {
-		err = sw.AddRelayerPeer(config.Sidecar.RelayerPeerString)
+		err = sw.SetRelayerPeer(config.Sidecar.RelayerPeerString)
 		if err != nil {
 			return nil, fmt.Errorf("could not add relayer from relayer_conn_string field: %w", err)
 		}

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -360,7 +360,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	sw.Logger.Info("Looking to reconnect after StopPeerForError, peer is ", peer, "relayer is ", sw.RelayerNetAddr)
 	if sw.RelayerNetAddr != nil && peer.ID() == sw.RelayerNetAddr.ID {
 		fmt.Println("Relayer peer disconnected, attempting to reconnect")
-		go sw.reconnectToRelayerPeer(sw.RelayerNetAddr)
+		go sw.reconnectToRelayerPeer()
 	} else if peer.IsPersistent() {
 		var addr *NetAddress
 		if peer.IsOutbound() { // socket address for outbound peers
@@ -421,22 +421,37 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 	}
 }
 
-func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
-	sw.Logger.Info("[relayer-reconnection]: starting relayer reconnect routine, addr is ", addr)
-	if sw.reconnecting.Has(string(addr.ID)) {
-		sw.Logger.Info("[relayer-reconnection]: already have a reconnection routine for ", addr)
+func (sw *Switch) reconnectToRelayerPeer() {
+	sw.Logger.Info("[relayer-reconnection]: starting relayer reconnect routine")
+	if sw.reconnecting.Has(sw.RelayerPeerString) {
+		sw.Logger.Info("[relayer-reconnection]: already have a reconnection routine for ", sw.RelayerPeerString)
 		return
 	}
-	sw.reconnecting.Set(string(addr.ID), addr)
-	defer sw.reconnecting.Delete(string(addr.ID))
+	sw.reconnecting.Set(sw.RelayerPeerString, struct{}{})
+	defer sw.reconnecting.Delete(sw.RelayerPeerString)
 
 	i := 0
 	for {
 		if !sw.IsRunning() {
 			return
 		}
+		i++
 
-		err := sw.DialPeerWithAddress(addr)
+		// This performs another IP lookup and saves the result in sw.RelayerNetAddr
+		err := sw.SetRelayerPeer(sw.RelayerPeerString)
+		if err != nil {
+			sw.Logger.Info(
+				"[relayer-reconnection]: Error resolving IP from relayer peer string. Trying again",
+				"tries", i,
+				"err", err,
+				"relayerPeerString", sw.RelayerPeerString,
+			)
+			sw.randomSleep(30 * time.Second)
+			continue
+		}
+		addr := sw.RelayerNetAddr
+
+		err = sw.DialPeerWithAddress(addr)
 		if err == nil {
 			return // success
 		} else if _, ok := err.(ErrCurrentlyDialingOrExistingAddress); ok {
@@ -446,7 +461,6 @@ func (sw *Switch) reconnectToRelayerPeer(addr *NetAddress) {
 		sw.Logger.Info("[relayer-reconnection]: Error reconnecting to relayer. Trying again", "tries", i, "err", err, "addr", addr)
 		// sleep a set amount
 		sw.randomSleep(30 * time.Second)
-		i++
 	}
 }
 
@@ -636,7 +650,7 @@ func (sw *Switch) IsDialingOrExistingAddress(addr *NetAddress) bool {
 		(!sw.config.AllowDuplicateIP && sw.peers.HasIP(addr.IP))
 }
 
-func (sw *Switch) AddRelayerPeer(addr string) error {
+func (sw *Switch) SetRelayerPeer(addr string) error {
 	sw.Logger.Info("Adding relayer as peer", "addr", addr)
 	netAddr, err := NewNetAddressString(addr)
 	if err != nil {
@@ -819,7 +833,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 	// XXX(xla): Remove the leakage of test concerns in implementation.
 	if cfg.TestDialFail {
 		if sw.RelayerNetAddr != nil && addr.ID == sw.RelayerNetAddr.ID {
-			go sw.reconnectToRelayerPeer(addr)
+			go sw.reconnectToRelayerPeer()
 			return fmt.Errorf("dial err relayer (peerConfig.DialFail == true)")
 		}
 		go sw.reconnectToPeer(addr)
@@ -849,7 +863,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 		// retry persistent peers after
 		// any dial error besides IsSelf()
 		if sw.RelayerNetAddr != nil && addr.ID == sw.RelayerNetAddr.ID {
-			go sw.reconnectToRelayerPeer(addr)
+			go sw.reconnectToRelayerPeer()
 		} else if sw.IsPeerPersistent(addr) {
 			go sw.reconnectToPeer(addr)
 		}

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -846,19 +846,19 @@ func BenchmarkSwitchBroadcast(b *testing.B) {
 	b.Logf("success: %v, failure: %v", numSuccess, numFailure)
 }
 
-func TestAddRelayerPeer(t *testing.T) {
+func TestSetRelayerPeer(t *testing.T) {
 	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
 	relayerString := "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656"
 	relayerNetAddr, _ := NewNetAddressString(relayerString)
 
-	err := sw.AddRelayerPeer(relayerString)
+	err := sw.SetRelayerPeer(relayerString)
 	if err != nil {
-		t.Errorf("Err in AddRelayerPeer: %s", err)
+		t.Errorf("Err in SetRelayerPeer: %s", err)
 	}
 
 	assert.Equal(t, relayerNetAddr, sw.RelayerNetAddr, "Expected RelayerNetAddr %s, got %s", relayerNetAddr, sw.RelayerNetAddr)
 
 	errRelayerString := "abcd@1.2.3.4:26656"
-	err = sw.AddRelayerPeer(errRelayerString)
+	err = sw.SetRelayerPeer(errRelayerString)
 	assert.True(t, err != nil, "Expected err with invalid relayer string")
 }


### PR DESCRIPTION
We currently save the DNS-resolved IP address of the relayer peer. This means that if the relayer's IP changes, peers will keep trying to reconnect to the old IP.
This PR changes the reconnect loop behavior to perform the IP lookup every time before attempting to dial the relayer.

- Rename `AddRelayerPeer` to `SetRelayerPeer` (more accurately describes what it actually does)
- Make `reconnectToRelayerPeer` call `SetRelayerPeer` on every loop, and dial the resulting address

----

Note: The way this works is that `SetRelayerPeer` calls `NewNetAddressString(<relayer string>)` which calls `net.LookupIP(host)`.
I think it's machine/compiler dependent whether `net.LookupIP` caches the DNS-resolved IP, so this is not 100% foolproof.
According to [this post](https://stackoverflow.com/questions/70468536/is-golang-caching-dns), compiling with CGO makes this cache.


----
@Zygimantass tested with docker testnet