### PR TITLE
[ENG-329] Add version to register node call

### DIFF
--- a/p2p/sentinel.go
+++ b/p2p/sentinel.go
@@ -10,17 +10,20 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	"github.com/tendermint/tendermint/version"
 )
 
 func RegisterWithSentinel(logger log.Logger, APIKey, peerID, sentinel string) {
+	version := version.MevTMVersion
 	logger.Info(
 		"[p2p.sentinel]: Registering with sentinel (first try)",
 		"API Key", APIKey,
 		"peerID", peerID,
+		"version", version,
 		"sentinel string", sentinel,
 	)
 
-	jsonData, err := makePostRequestData(peerID, APIKey)
+	jsonData, err := makePostRequestData(peerID, APIKey, version)
 	if err != nil {
 		logger.Info("[p2p.sentinel]: Err marshalling json data:", err)
 		return
@@ -88,10 +91,10 @@ func postRequestRoutine(logger log.Logger, sentinel string, jsonData []byte) {
 	}
 }
 
-func makePostRequestData(peerID, APIKey string) ([]byte, error) {
-	params := [2]string{peerID, APIKey}
+func makePostRequestData(peerID, APIKey, version string) ([]byte, error) {
+	params := [3]string{peerID, APIKey, version}
 	data := map[string]interface{}{
-		"method": "register_node_api",
+		"method": "register_node",
 		"params": params,
 		"id":     1,
 	}

--- a/p2p/sentinel_test.go
+++ b/p2p/sentinel_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/version"
 )
 
 func TestPostRequestRoutine(t *testing.T) {
@@ -32,8 +33,8 @@ func TestPostRequestRoutine(t *testing.T) {
 		if id := body["id"].(float64); id != float64(1) {
 			t.Errorf("Expected post body to have id=%f, got %f", float64(1), id)
 		}
-		if method := body["method"].(string); method != "register_node_api" {
-			t.Errorf("Expected post body to have method=%s, got %s", "add_node_api", method)
+		if method := body["method"].(string); method != "register_node" {
+			t.Errorf("Expected post body to have method=%s, got %s", "register_node", method)
 		}
 		params := body["params"].([]interface{})
 		if peerID := params[0].(string); peerID != "a1b2c3d4" {
@@ -41,6 +42,9 @@ func TestPostRequestRoutine(t *testing.T) {
 		}
 		if apikey := params[1].(string); apikey != "test-api-key" {
 			t.Errorf("Expected post body params to have apikey %s, got %s", "test-api-key", apikey)
+		}
+		if versionParam := params[2].(string); versionParam != version.MevTMVersion {
+			t.Errorf("Expected post body params to have version %s, got %s", version.MevTMVersion, versionParam)
 		}
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(`{"jsonrpc": "2.0", "id": 1, "result": "success"}`))
@@ -50,7 +54,7 @@ func TestPostRequestRoutine(t *testing.T) {
 	}))
 	defer server.Close()
 
-	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key", version.MevTMVersion)
 	postRequestRoutine(log.NewNopLogger(), server.URL, jsonData)
 }
 
@@ -67,7 +71,7 @@ func TestPostRequestRoutine_DoesNotPanicOn500(t *testing.T) {
 	}))
 	defer server.Close()
 
-	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key", version.MevTMVersion)
 	err := attemptRegisterOnce(log.NewNopLogger(), server.URL, jsonData)
 	if err == nil {
 		t.Errorf("Expected error on fake server")
@@ -85,7 +89,7 @@ func TestErrorOnJSONRPCError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key", version.MevTMVersion)
 	err := attemptRegisterOnce(log.NewNopLogger(), server.URL, jsonData)
 	if err == nil {
 		t.Errorf("Expected error on jsonrpc error")
@@ -93,7 +97,7 @@ func TestErrorOnJSONRPCError(t *testing.T) {
 }
 
 func TestErrorOnFailedToRespond(t *testing.T) {
-	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key")
+	jsonData, _ := makePostRequestData("a1b2c3d4", "test-api-key", version.MevTMVersion)
 	err := attemptRegisterOnce(log.NewNopLogger(), "http://1.2.3.4:6969", jsonData)
 	if err == nil {
 		t.Errorf("Expected error on fake server")

--- a/version/version.go
+++ b/version/version.go
@@ -12,6 +12,8 @@ const (
 	ABCISemVer = "0.17.0"
 
 	ABCIVersion = ABCISemVer
+
+	MevTMVersion = "v0.34.21-mev.13"
 )
 
 var (


### PR DESCRIPTION
1. Use the new `register_node` api, which includes passing a version
2. Add `MevTMVersion` to `version/version.go`

