### PR TITLE
[ENG-338] Start relayer reconnection check routine on node start

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -576,16 +576,6 @@ func createTransport(
 	return transport, peerFilters
 }
 
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
-}
-
 func createSwitch(config *cfg.Config,
 	transport p2p.Transport,
 	p2pMetrics *p2p.Metrics,
@@ -598,19 +588,7 @@ func createSwitch(config *cfg.Config,
 	nodeInfo p2p.NodeInfo,
 	nodeKey *p2p.NodeKey,
 	p2pLogger log.Logger) *p2p.Switch {
-	peerList := splitAndTrimEmpty(config.Sidecar.PersonalPeerIDs, ",", " ")
-
-	if config.Sidecar.RelayerPeerString != "" {
-		relayerID := strings.Split(config.Sidecar.RelayerPeerString, "@")[0]
-		if !contains(peerList, relayerID) {
-			peerList = append(peerList, relayerID)
-		}
-	}
-
-	sidecarPeers, err := p2p.NewSidecarPeers(peerList)
-	if err != nil {
-		panic(fmt.Sprintln("Problem with peer initialization", err))
-	}
+	sidecarPeers := splitAndTrimEmpty(config.Sidecar.PersonalPeerIDs, ",", " ")
 
 	sw := p2p.NewSwitch(
 		config.P2P,
@@ -1079,6 +1057,7 @@ func (n *Node) OnStart() error {
 	if err != nil {
 		return fmt.Errorf("could not dial peers from persistent_peers field: %w", err)
 	}
+	n.sw.StartRelayerConnectionCheckRoutine()
 
 	// Run state sync
 	if n.stateSync {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -92,9 +92,11 @@ type Switch struct {
 	rng *rand.Rand // seed for randomizing dial times and orders
 
 	metrics           *Metrics
-	sidecarPeers      SidecarPeers
+	sidecarPeers      sidecarPeers
 	RelayerPeerString string
 	RelayerNetAddr    *NetAddress
+
+	relayerReconnectionMtx sync.Mutex
 }
 
 // NetAddress returns the address the switch is listening on.
@@ -106,12 +108,12 @@ func (sw *Switch) NetAddress() *NetAddress {
 // SwitchOption sets an optional parameter on the Switch.
 type SwitchOption func(*Switch)
 
-type SidecarPeers map[ID]struct{}
+type sidecarPeers map[ID]struct{}
 
 // create map of sidecar peers that will privately gossip
 // auction-winning txs among themselves
-func NewSidecarPeers(pl []string) (SidecarPeers, error) {
-	sp := make(SidecarPeers)
+func newSidecarPeers(pl []string) (sidecarPeers, error) {
+	sp := make(sidecarPeers)
 	for _, pid := range pl {
 		if pid == "" {
 			continue
@@ -128,14 +130,13 @@ func NewSidecarPeers(pl []string) (SidecarPeers, error) {
 // NewSwitch creates a new Switch with the given config.
 func NewSwitch(
 	cfg *config.P2PConfig,
-	sidecarPeers SidecarPeers,
+	sidecarPeerList []string,
 	transport Transport,
 	relayerPeerString string,
 	options ...SwitchOption,
 ) *Switch {
 	sw := &Switch{
 		config:               cfg,
-		sidecarPeers:         sidecarPeers,
 		reactors:             make(map[string]Reactor),
 		chDescs:              make([]*conn.ChannelDescriptor, 0),
 		reactorsByCh:         make(map[byte]Reactor),
@@ -149,6 +150,18 @@ func NewSwitch(
 		unconditionalPeerIDs: make(map[ID]struct{}),
 		RelayerPeerString:    relayerPeerString,
 	}
+
+	if relayerPeerString != "" {
+		relayerID := strings.Split(relayerPeerString, "@")[0]
+		if !contains(sidecarPeerList, relayerID) {
+			sidecarPeerList = append(sidecarPeerList, relayerID)
+		}
+	}
+	sidecarPeers, err := newSidecarPeers(sidecarPeerList)
+	if err != nil {
+		panic(fmt.Sprintln("Problem with peer initialization", err))
+	}
+	sw.sidecarPeers = sidecarPeers
 
 	// Ensure we have a completely undeterministic PRNG.
 	sw.rng = rand.NewRand()
@@ -359,7 +372,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 
 	sw.Logger.Info("Looking to reconnect after StopPeerForError, peer is ", peer, "relayer is ", sw.RelayerNetAddr)
 	if sw.RelayerNetAddr != nil && peer.ID() == sw.RelayerNetAddr.ID {
-		fmt.Println("Relayer peer disconnected, attempting to reconnect")
+		sw.Logger.Info("Relayer peer disconnected, attempting to reconnect")
 		go sw.reconnectToRelayerPeer()
 	} else if peer.IsPersistent() {
 		var addr *NetAddress
@@ -423,11 +436,21 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 
 func (sw *Switch) reconnectToRelayerPeer() {
 	sw.Logger.Info("[relayer-reconnection]: starting relayer reconnect routine")
-	if sw.reconnecting.Has(sw.RelayerPeerString) {
-		sw.Logger.Info("[relayer-reconnection]: already have a reconnection routine for ", sw.RelayerPeerString)
+	shouldReturn := func() bool {
+		sw.relayerReconnectionMtx.Lock()
+		defer sw.relayerReconnectionMtx.Unlock()
+
+		if sw.reconnecting.Has(sw.RelayerPeerString) {
+			sw.Logger.Info("[relayer-reconnection]: already have a reconnection routine for ", sw.RelayerPeerString)
+			return true
+		}
+		sw.reconnecting.Set(sw.RelayerPeerString, struct{}{})
+		return false
+	}()
+	if shouldReturn {
 		return
 	}
-	sw.reconnecting.Set(sw.RelayerPeerString, struct{}{})
+
 	defer sw.reconnecting.Delete(sw.RelayerPeerString)
 
 	i := 0
@@ -975,4 +998,31 @@ func (sw *Switch) addPeer(p Peer) error {
 	sw.Logger.Info("Added peer", "peer", p)
 
 	return nil
+}
+
+func (sw *Switch) StartRelayerConnectionCheckRoutine() {
+	go func() {
+		for {
+			// Do this check roughly every 5 minutes
+			sw.randomSleep(5 * 60 * time.Second)
+
+			sw.Logger.Info("[relayer-check]: Entering periodic check for relayer peer connection")
+			if !sw.peers.Has(ID(strings.Split(sw.RelayerPeerString, "@")[0])) {
+				sw.Logger.Info("[relayer-check]: Relayer connection check routine didn't find relayer peer, starting reconnection routine")
+				go sw.reconnectToRelayerPeer()
+			} else {
+				sw.Logger.Info("[relayer-check]: Found existing connection to relayer, going back to sleep")
+			}
+		}
+	}()
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -939,6 +939,10 @@ func (sw *Switch) filterPeer(p Peer) error {
 // the peer is filtered out or failed to start or can't be added.
 func (sw *Switch) addPeer(p Peer) error {
 	if err := sw.filterPeer(p); err != nil {
+		// if peer is relayer, log the error
+		if sw.RelayerNetAddr != nil && p.ID() == sw.RelayerNetAddr.ID {
+			sw.Logger.Error("[relayer-reconnection]: filterPeer filtered relayer", "err", err)
+		}
 		return err
 	}
 

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -186,7 +186,7 @@ func assertMsgReceivedWithTimeout(
 func TestSidecarPeerMap(t *testing.T) {
 	s1 := MakeSwitch(cfg, 1, "127.0.0.1", "123.123.123", initSwitchFunc)
 	s1id := string(s1.nodeInfo.ID())
-	sp, _ := NewSidecarPeers([]string{s1id})
+	sp := []string{s1id}
 	s2 := MakeSwitchWithSidecarPeers(cfg, 2, "127.0.0.1", "123.123.124", initSwitchFunc, sp)
 	assert.True(t, s2.IsSidecarPeer(s1.nodeInfo.ID()))
 }
@@ -697,7 +697,7 @@ func (errorTransport) Cleanup(Peer) {
 }
 
 func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
-	sw := NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrFilterTimeout{}}, "")
+	sw := NewSwitch(cfg, make([]string, 0), errorTransport{ErrFilterTimeout{}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
 		require.NoError(t, err)
@@ -705,7 +705,7 @@ func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	sw = NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrRejected{
+	sw = NewSwitch(cfg, make([]string, 0), errorTransport{ErrRejected{
 		conn: nil, err: errors.New("filtered"), isFiltered: true}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
@@ -715,7 +715,7 @@ func TestSwitchAcceptRoutineErrorCases(t *testing.T) {
 	})
 	// TODO(melekes) check we remove our address from addrBook
 
-	sw = NewSwitch(cfg, make(SidecarPeers, 0), errorTransport{ErrTransportClosed{}}, "")
+	sw = NewSwitch(cfg, make([]string, 0), errorTransport{ErrTransportClosed{}}, "")
 	assert.NotPanics(t, func() {
 		err := sw.Start()
 		require.NoError(t, err)

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -205,7 +205,7 @@ func MakeSwitchWithSidecarPeers(
 	i int,
 	network, version string,
 	initSwitch func(int, *Switch) *Switch,
-	sp SidecarPeers,
+	sp []string,
 	opts ...SwitchOption,
 ) *Switch {
 
@@ -270,7 +270,7 @@ func MakeSwitch(
 	}
 
 	// TODO: let the config be passed in?
-	sw := initSwitch(i, NewSwitch(cfg, make(SidecarPeers, 0), t, "", opts...))
+	sw := initSwitch(i, NewSwitch(cfg, make([]string, 0), t, "", opts...))
 	sw.SetLogger(log.TestingLogger().With("switch", i))
 	sw.SetNodeKey(&nodeKey)
 

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -601,7 +601,7 @@ func createSwitch(config *cfg.Config,
 
 	sw := p2p.NewSwitch(
 		config.P2P,
-		make(p2p.SidecarPeers, 0),
+		make([]string, 0),
 		transport,
 		"",
 		p2p.WithMetrics(p2pMetrics),


### PR DESCRIPTION
This adds a new "check" goroutine in node startup that does a check every 5 mins for the relayer peer. If the p2p switch doesn't have the relayer peer, the check routine starts the reconnection routine.

Additional changes:
- Refactor `NewSwitch` - since this already takes the RelayerPeerString and the sidecar peers, we should have it combine them, not the caller.
- Make `sidecarPeers` private, since it was only public to support the above (caller passed one in, when it really doesn't need to know about that type at all).
- Make `reconnectToRelayerPeer` actually thread-safe (only one runs at a time) -- currently if it's called by two threads simultaneously, it's possible for 2 goroutines to be running it at the same time

