### PR TITLE
move reconnection out to ensurePeers

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -949,6 +949,8 @@ func NewNode(config *cfg.Config,
 	var pexReactor *pex.Reactor
 	if config.P2P.PexReactor {
 		pexReactor = createPEXReactorAndAddToSwitch(addrBook, config, sw, logger)
+	} else {
+		sw.StartSentinelConnectionRoutineWithNoPEX()
 	}
 
 	if config.RPC.PprofListenAddress != "" {
@@ -1096,7 +1098,6 @@ func (n *Node) OnStart() error {
 	if err != nil {
 		return fmt.Errorf("could not dial peers from persistent_peers field: %w", err)
 	}
-	n.sw.StartSentinelConnectionCheckRoutine()
 
 	// Run state sync
 	if n.stateSync {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -539,7 +539,7 @@ func (r *Reactor) ensurePeers() {
 func (r *Reactor) attemptReconnectToSentinelPeer() {
 	r.Logger.Info("[sentinel-check]: Entering pex_reactor check for sentinel peer connection")
 	if !r.Switch.Peers().Has(p2p.ID(strings.Split(r.Switch.SentinelPeerString, "@")[0])) {
-		r.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection routine")
+		r.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection attempt")
 		go r.Switch.ReconnectToSentinelPeer()
 	} else {
 		r.Logger.Info("[sentinel-check]: Found existing connection to sentinel peer, no need to reconnect")
@@ -760,7 +760,7 @@ func (r *Reactor) attemptDisconnects() {
 		if peer.Status().Duration < r.config.SeedDisconnectWaitPeriod {
 			continue
 		}
-		if peer.IsPersistent() {
+		if peer.IsPersistent() || peer.IsSidecarPeer() {
 			continue
 		}
 		r.Switch.StopPeerGracefully(peer)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -3,6 +3,7 @@ package pex
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -462,6 +463,14 @@ func (r *Reactor) ensurePeers() {
 		"numDialing", dial,
 		"numToDial", numToDial,
 	)
+
+	r.Logger.Info("[sentinel-check]: Entering ensurePeers check for sentinel peer connection")
+	if !r.Switch.Peers().Has(p2p.ID(strings.Split(r.Switch.SentinelPeerString, "@")[0])) {
+		r.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection routine")
+		go r.Switch.ReconnectToSentinelPeer()
+	} else {
+		r.Logger.Info("[sentinel-check]: Found existing connection to sentinel peer, no need to reconnect")
+	}
 
 	if numToDial <= 0 {
 		return

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -439,21 +439,19 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 
 // Ensures that sufficient peers are connected. (continuous)
 func (sw *Switch) StartSentinelConnectionRoutineWithNoPEX() {
-
 	// fire periodically
-	ticker := time.NewTicker(30 * time.Second)
-	for {
-		select {
-		case <-ticker.C:
-			sw.Logger.Info("[sentinel-check]: Entering ensurePeers check for sentinel peer connection")
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		for _ = range ticker.C {
+			sw.Logger.Info("[sentinel-check]: Entering SentinelConnectionRoutineWithNoPEX check for sentinel peer connection")
 			if !sw.peers.Has(ID(strings.Split(sw.SentinelPeerString, "@")[0])) {
 				sw.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection routine")
-				go sw.ReconnectToSentinelPeer()
+				sw.ReconnectToSentinelPeer()
 			} else {
 				sw.Logger.Info("[sentinel-check]: Found existing connection to sentinel peer, no need to reconnect")
 			}
 		}
-	}
+	}()
 }
 
 func (sw *Switch) ReconnectToSentinelPeer() {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -439,13 +439,12 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 
 // Ensures that sufficient peers are connected. (continuous)
 func (sw *Switch) StartSentinelConnectionRoutineWithNoPEX() {
-	// fire periodically
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
-		for _ = range ticker.C {
+		for range ticker.C {
 			sw.Logger.Info("[sentinel-check]: Entering SentinelConnectionRoutineWithNoPEX check for sentinel peer connection")
 			if !sw.peers.Has(ID(strings.Split(sw.SentinelPeerString, "@")[0])) {
-				sw.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection routine")
+				sw.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection attempt")
 				sw.ReconnectToSentinelPeer()
 			} else {
 				sw.Logger.Info("[sentinel-check]: Found existing connection to sentinel peer, no need to reconnect")


### PR DESCRIPTION
This is to fix reconnection jittering causing missed blocks in very rare cases.

Major changes:
- Moved all Sentinel reconnection logic when pex=true to `ensurePeers`, and removed additional goroutines
- Removed Sentinel reconnection logic from addOutBoundPeers and the Dial functions
- Kept 30s reconnection logic when pex=false, but modified to use Tickers (similar to ensurePeers)

prayge

