### PR TITLE
[DO NOT MERGE] Make sentinel a normal persistent peer

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -92,13 +92,9 @@ type Switch struct {
 
 	rng *rand.Rand // seed for randomizing dial times and orders
 
-	metrics            *Metrics
-	mevMetrics         *mev.Metrics
-	sidecarPeers       sidecarPeers
-	SentinelPeerString string
-	SentinelNetAddr    *NetAddress
-
-	sentinelReconnectionMtx sync.Mutex
+	metrics      *Metrics
+	mevMetrics   *mev.Metrics
+	sidecarPeers sidecarPeers
 }
 
 // NetAddress returns the address the switch is listening on.
@@ -150,7 +146,6 @@ func NewSwitch(
 		filterTimeout:        defaultFilterTimeout,
 		persistentPeersAddrs: make([]*NetAddress, 0),
 		unconditionalPeerIDs: make(map[ID]struct{}),
-		SentinelPeerString:   sentinelPeerString,
 	}
 
 	if sentinelPeerString != "" {
@@ -376,11 +371,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	sw.Logger.Error("Stopping peer for error", "peer", peer, "err", reason)
 	sw.stopAndRemovePeer(peer, reason)
 
-	sw.Logger.Info("Looking to reconnect after StopPeerForError, peer is ", peer, "sentinel is ", sw.SentinelNetAddr)
-	if sw.SentinelNetAddr != nil && peer.ID() == sw.SentinelNetAddr.ID {
-		sw.Logger.Info("Sentinel peer disconnected, attempting to reconnect")
-		go sw.reconnectToSentinelPeer()
-	} else if peer.IsPersistent() {
+	if peer.IsPersistent() {
 		var addr *NetAddress
 		if peer.IsOutbound() { // socket address for outbound peers
 			addr = peer.SocketAddr()
@@ -421,75 +412,6 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 	// https://github.com/tendermint/tendermint/issues/3338
 	if sw.peers.Remove(peer) {
 		sw.metrics.Peers.Add(float64(-1))
-
-		// check if we removed sentinel, if so, alert metrics
-		splitStr := strings.Split(sw.SentinelPeerString, "@")
-		if len(splitStr) > 1 {
-			sentinelIDConv := ID(splitStr[0])
-			if err := validateID(sentinelIDConv); err == nil {
-				if peer.ID() == sentinelIDConv {
-					sw.mevMetrics.SentinelConnected.Set(0)
-				}
-			} else {
-				sw.Logger.Error("Error validating sentinel ID", "err", err, "is it correctly configured?", sw.SentinelPeerString)
-			}
-		} else {
-			sw.Logger.Error("Error splitting sentinel ID", "is it correctly configured?", sw.SentinelPeerString)
-		}
-
-	}
-}
-
-func (sw *Switch) reconnectToSentinelPeer() {
-	sw.Logger.Info("[sentinel-reconnection]: starting sentinel reconnect routine")
-	shouldReturn := func() bool {
-		sw.sentinelReconnectionMtx.Lock()
-		defer sw.sentinelReconnectionMtx.Unlock()
-
-		if sw.reconnecting.Has(sw.SentinelPeerString) {
-			sw.Logger.Info("[sentinel-reconnection]: already have a reconnection routine for ", sw.SentinelPeerString)
-			return true
-		}
-		sw.reconnecting.Set(sw.SentinelPeerString, struct{}{})
-		return false
-	}()
-	if shouldReturn {
-		return
-	}
-
-	defer sw.reconnecting.Delete(sw.SentinelPeerString)
-
-	i := 0
-	for {
-		if !sw.IsRunning() {
-			return
-		}
-		i++
-
-		// This performs another IP lookup and saves the result in sw.SentinelNetAddr
-		err := sw.SetSentinelPeer(sw.SentinelPeerString)
-		if err != nil {
-			sw.Logger.Info(
-				"[sentinel-reconnection]: Error resolving IP from sentinel peer string. Trying again",
-				"tries", i,
-				"err", err,
-				"sentinelPeerString", sw.SentinelPeerString,
-			)
-			sw.randomSleep(30 * time.Second)
-			continue
-		}
-		addr := sw.SentinelNetAddr
-
-		err = sw.DialPeerWithAddress(addr)
-		if err == nil {
-			return // success
-		} else if _, ok := err.(ErrCurrentlyDialingOrExistingAddress); ok {
-			return
-		}
-
-		sw.Logger.Info("[sentinel-reconnection]: Error reconnecting to sentinel. Trying again", "tries", i, "err", err, "addr", addr)
-		// sleep a set amount
-		sw.randomSleep(30 * time.Second)
 	}
 }
 
@@ -679,17 +601,6 @@ func (sw *Switch) IsDialingOrExistingAddress(addr *NetAddress) bool {
 		(!sw.config.AllowDuplicateIP && sw.peers.HasIP(addr.IP))
 }
 
-func (sw *Switch) SetSentinelPeer(addr string) error {
-	sw.Logger.Info("Adding sentinel as peer", "addr", addr)
-	netAddr, err := NewNetAddressString(addr)
-	if err != nil {
-		sw.Logger.Error("Error in sentinel's address", "err", err)
-		return err
-	}
-	sw.SentinelNetAddr = netAddr
-	return nil
-}
-
 // AddPersistentPeers allows you to set persistent peers. It ignores
 // ErrNetAddressLookup. However, if there are other errors, first encounter is
 // returned.
@@ -852,18 +763,10 @@ func (sw *Switch) addOutboundPeerWithConfig(
 	addr *NetAddress,
 	cfg *config.P2PConfig,
 ) error {
-	if sw.SentinelNetAddr != nil && addr.ID == sw.SentinelNetAddr.ID {
-		sw.Logger.Info("[sentinel-reconnection]: DIALING SENTINEL", "address", addr, "time", time.Now())
-	} else {
-		sw.Logger.Info("Dialing peer", "address", addr)
-	}
+	sw.Logger.Info("Dialing peer", "address", addr)
 
 	// XXX(xla): Remove the leakage of test concerns in implementation.
 	if cfg.TestDialFail {
-		if sw.SentinelNetAddr != nil && addr.ID == sw.SentinelNetAddr.ID {
-			go sw.reconnectToSentinelPeer()
-			return fmt.Errorf("dial err sentinel (peerConfig.DialFail == true)")
-		}
 		go sw.reconnectToPeer(addr)
 		return fmt.Errorf("dial err (peerConfig.DialFail == true)")
 	}
@@ -890,9 +793,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 
 		// retry persistent peers after
 		// any dial error besides IsSelf()
-		if sw.SentinelNetAddr != nil && addr.ID == sw.SentinelNetAddr.ID {
-			go sw.reconnectToSentinelPeer()
-		} else if sw.IsPeerPersistent(addr) {
+		if sw.IsPeerPersistent(addr) {
 			go sw.reconnectToPeer(addr)
 		}
 
@@ -905,8 +806,6 @@ func (sw *Switch) addOutboundPeerWithConfig(
 			_ = p.Stop()
 		}
 		return err
-	} else if sw.SentinelNetAddr != nil && addr.ID == sw.SentinelNetAddr.ID {
-		sw.Logger.Info("[sentinel-reconnection]: SENTINEL RECONNECTED!", "address", addr)
 	}
 
 	return nil
@@ -944,10 +843,6 @@ func (sw *Switch) filterPeer(p Peer) error {
 // the peer is filtered out or failed to start or can't be added.
 func (sw *Switch) addPeer(p Peer) error {
 	if err := sw.filterPeer(p); err != nil {
-		// if peer is sentinel, log the error
-		if sw.SentinelNetAddr != nil && p.ID() == sw.SentinelNetAddr.ID {
-			sw.Logger.Error("[sentinel-reconnection]: filterPeer filtered sentinel", "err", err)
-		}
 		return err
 	}
 
@@ -984,21 +879,6 @@ func (sw *Switch) addPeer(p Peer) error {
 	}
 	sw.metrics.Peers.Add(float64(1))
 
-	// check if we removed sentinel, if so, alert metrics
-	splitStr := strings.Split(sw.SentinelPeerString, "@")
-	if len(splitStr) > 1 {
-		sentinelIDConv := ID(splitStr[0])
-		if err := validateID(sentinelIDConv); err == nil {
-			if p.ID() == sentinelIDConv {
-				sw.mevMetrics.SentinelConnected.Set(1)
-			}
-		} else {
-			sw.Logger.Error("Error validating sentinel ID", "err", err, "is it correctly configured?", sw.SentinelPeerString)
-		}
-	} else {
-		sw.Logger.Error("Error splitting sentinel ID", "is it correctly configured?", sw.SentinelPeerString)
-	}
-
 	// Start all the reactor protocols on the peer.
 	for _, reactor := range sw.reactors {
 		reactor.AddPeer(p)
@@ -1007,23 +887,6 @@ func (sw *Switch) addPeer(p Peer) error {
 	sw.Logger.Info("Added peer", "peer", p)
 
 	return nil
-}
-
-func (sw *Switch) StartSentinelConnectionCheckRoutine() {
-	go func() {
-		for {
-			// Do this check roughly every 5 minutes
-			sw.randomSleep(5 * 60 * time.Second)
-
-			sw.Logger.Info("[sentinel-check]: Entering periodic check for sentinel peer connection")
-			if !sw.peers.Has(ID(strings.Split(sw.SentinelPeerString, "@")[0])) {
-				sw.Logger.Info("[sentinel-check]: Sentinel connection check routine didn't find sentinel peer, starting reconnection routine")
-				go sw.reconnectToSentinelPeer()
-			} else {
-				sw.Logger.Info("[sentinel-check]: Found existing connection to sentinel, going back to sleep")
-			}
-		}
-	}()
 }
 
 func contains(s []string, str string) bool {

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -845,20 +845,3 @@ func BenchmarkSwitchBroadcast(b *testing.B) {
 
 	b.Logf("success: %v, failure: %v", numSuccess, numFailure)
 }
-
-func TestSetSentinelPeer(t *testing.T) {
-	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
-	sentinelString := "79044d1d81d24a8ff3c7fd7e010f455f7ae9e1ad@1.2.3.4:26656"
-	sentinelNetAddr, _ := NewNetAddressString(sentinelString)
-
-	err := sw.SetSentinelPeer(sentinelString)
-	if err != nil {
-		t.Errorf("Err in SetSentinelPeer: %s", err)
-	}
-
-	assert.Equal(t, sentinelNetAddr, sw.SentinelNetAddr, "Expected SentinelNetAddr %s, got %s", sentinelNetAddr, sw.SentinelNetAddr)
-
-	errSentinelString := "abcd@1.2.3.4:26656"
-	err = sw.SetSentinelPeer(errSentinelString)
-	assert.True(t, err != nil, "Expected err with invalid sentinel string")
-}


### PR DESCRIPTION
This is the diff to remove special treatment of the sentinel as a peer, and just treat it as a normal persistent, unconditional, private peer.
Note that this also removes the DNS-refresh logic, so if the IP of the sentinel changes, the mev-tm node will need to be restarted.

Tested on internal juno testnet