### PR TITLE
[ENG-426] Use tx.Hash() to log reaped sidecar txs

### DIFF
--- a/mempool/mev_reap.go
+++ b/mempool/mev_reap.go
@@ -1,6 +1,8 @@
 package mempool
 
 import (
+	"encoding/hex"
+
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
 )
@@ -44,7 +46,7 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 		sidecarTxsMap[sidecarTx.Key()] = struct{}{}
 		logger.Info(
 			"[mev-tendermint]: reaped sidecar",
-			"mev transaction", getLastNumBytesFromTx(sidecarTx, 20),
+			"mev transaction", hex.EncodeToString(sidecarTx.Hash()),
 			"gasWanted", sidecarTxs.GasWanteds[i],
 		)
 	}
@@ -52,7 +54,7 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 	for i, memplTx := range memplTxs.Txs {
 		if _, ok := sidecarTxsMap[memplTx.Key()]; ok {
 			// SKIP THIS TRANSACTION, ALREADY SEEN IN SIDECAR
-			logger.Info("[mev-tendermint]: skipped mempool tx, already found in sidecar", getLastNumBytesFromTx(memplTx, 20))
+			logger.Info("[mev-tendermint]: skipped mempool tx, already found in sidecar", hex.EncodeToString(memplTx.Hash()))
 			continue
 		}
 
@@ -76,14 +78,4 @@ func CombineSidecarAndMempoolTxs(memplTxs, sidecarTxs types.ReapedTxs, maxBytes,
 		txs = append(txs, memplTx)
 	}
 	return txs
-}
-
-func getLastNumBytesFromTx(tx types.Tx, numBytes int) string {
-	if len(tx) == 0 {
-		return ""
-	} else if len(tx) < 20 {
-		return tx.String()
-	} else {
-		return tx.String()[len(tx.String())-20:]
-	}
 }


### PR DESCRIPTION
In `mev_reap`, we log txs using `GetLastNumBytesFromTx`, which prints the last 20 bytes of the actual tx. The rest of tendermint uses `tx.Hash()`, which is a hash of all of the bytes in the tx.
This makes these logs different from explorers and our database, so val logs can't be easily matched to other sources or the rest of tendermint.

This PR removes GetLastNumBytesFromTx and replaces usage with tx.Hash().

New reap logs look like this:
![image](https://user-images.githubusercontent.com/15060257/212961269-69f94ff3-0916-489b-ac09-69d9a04b82da.png)
