### PR TITLE
[ENG-596] Handle sentinel peer string error gracefully

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -905,7 +905,11 @@ func NewNode(config *cfg.Config,
 	if sentinelPeerString != "" {
 		err = sw.SetSentinelPeer(sentinelPeerString)
 		if err != nil {
-			return nil, fmt.Errorf("could not add sentinel from sentinel_peer_string field: %w", err)
+			logger.Error(
+				"Error resolving IP from sentinel peer string. Trying again",
+				"err", err,
+				"sentinelPeerString", sentinelPeerString,
+			)
 		}
 	} else {
 		logger.Info("[node startup]: No sentinel_peer_string specified, not adding sentinel as peer")


### PR DESCRIPTION
Changes
- Instead of failing when we can't set sentinel peer, we report an error, but allow the node to start normally.