### PR TITLE
[ENG-626] Add sidecar tag to config default template

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -538,6 +538,8 @@ namespace = "{{ .Instrumentation.Namespace }}"
 #######################################################
 ###       Sidecar Configuration Options          ###
 #######################################################
+[sidecar]
+
 # comma separated list of peer ids that represent the nodes
 # you run that this node is aware of / can communicate with
 # (This allows private sidecar gossiping to ensure only your validator and the other


### PR DESCRIPTION
Default template for config is missing the `[sidecar]` tag, so when you use the default template to generate the config, there's no sidecar tag.
