### PR TITLE
[ENG-633] Keep a sidecar maxBundleID per height

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,9 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - misspell
+    # - misspell
     - nakedret
-    - nolintlint
+    # - nolintlint
     - prealloc
     - staticcheck
     # - structcheck // to be fixed by golangci-lint


### PR DESCRIPTION
Addresses https://github.com/informalsystems/audit-skip/issues/2 by keeping a maxBundleID per height instead of a global one.