### PR TITLE
[ENG-633] Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,9 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - misspell
+    # - misspell
     - nakedret
-    - nolintlint
+    # - nolintlint
     - prealloc
     - staticcheck
     # - structcheck // to be fixed by golangci-lint


### PR DESCRIPTION
Two issues with linter:
- misspell is rejecting British spellings of things
- nolintlint and gofmt conflict -- nolintlint wants nolint directives to not have a space between `//` and the nolint directive, while gofmt wants a space after all `//`